### PR TITLE
Signals & Hands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,24 +20,24 @@ checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
 name = "accesskit"
-version = "0.11.2"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76eb1adf08c5bcaa8490b9851fd53cca27fa9880076f178ea9d29f05196728a8"
+checksum = "ca8410747ed85a17c4a1e9ed3f5a74d3e7bdcc876cf9a18ff40ae21d645997b2"
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.15.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04bb4d9e4772fe0d47df57d0d5dbe5d85dd05e2f37ae1ddb6b105e76be58fb00"
+checksum = "8c17cca53c09fbd7288667b22a201274b9becaa27f0b91bf52a526db95de45e6"
 dependencies = [
  "accesskit",
 ]
 
 [[package]]
 name = "accesskit_macos"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134d0acf6acb667c89d3332999b1a5df4edbc8d6113910f392ebb73f2b03bb56"
+checksum = "cd3b6ae1eabbfbced10e840fd3fce8a93ae84f174b3e4ba892ab7bcb42e477a7"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
@@ -47,23 +47,23 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.14.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eac0a7f2d7cd7a93b938af401d3d8e8b7094217989a7c25c55a953023436e31"
+checksum = "afcae27ec0974fc7c3b0b318783be89fd1b2e66dd702179fe600166a38ff4a0b"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "arrayvec",
  "once_cell",
  "paste",
+ "static_assertions",
  "windows 0.48.0",
 ]
 
 [[package]]
 name = "accesskit_winit"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825d23acee1bd6d25cbaa3ca6ed6e73faf24122a774ec33d52c5c86c6ab423c0"
+checksum = "88e39fcec2e10971e188730b7a76bab60647dacc973d4591855ebebcadfaa738"
 dependencies = [
  "accesskit",
  "accesskit_macos",
@@ -176,12 +176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -189,6 +183,12 @@ checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
 
 [[package]]
 name = "arrayvec"
@@ -206,6 +206,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c48ccdbf6ca6b121e0f586cbc0e73ae440e56c67c30fa0873b4e110d9c26d2b"
+dependencies = [
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
 name = "async-channel"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -217,17 +227,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ca33f4bc4ed1babef42cad36cc1f51fa88be00420404e5b1e80ab1b18f7678c"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 4.0.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-executor"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
- "async-lock",
+ "async-lock 3.1.2",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
  "futures-lite 2.0.1",
  "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279cf904654eeebfa37ac9bb1598880884924aab82e290aa65c9e77a0e142e06"
+dependencies = [
+ "async-lock 2.8.0",
+ "autocfg",
+ "blocking",
+ "futures-lite 1.13.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+dependencies = [
+ "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -246,6 +290,12 @@ name = "async-task"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -282,18 +332,30 @@ checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bevy"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c6d3ec4f89e85294dc97334c5b271ddc301fdf67ac9bb994fe44d9273e6ed7"
+checksum = "e4bc7e09282a82a48d70ade0c4c1154b0fd7882a735a39c66766a5d0f4718ea9"
 dependencies = [
  "bevy_internal",
 ]
 
 [[package]]
+name = "bevy-vello"
+version = "0.3.7"
+source = "git+https://github.com/vectorgameexperts/bevy-vello.git?rev=v0.3#18a575194a53b53821dfc3c1ecbcf659ee5e50a9"
+dependencies = [
+ "bevy",
+ "flate2",
+ "vello",
+ "vello-svg",
+ "vellottie",
+]
+
+[[package]]
 name = "bevy_a11y"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132c9e35a77c5395951f6d25fa2c52ee92296353426df4f961e60f3ff47e2e42"
+checksum = "68080288c932634f6563d3a8299efe0ddc9ea6787539c4c771ba250d089a94f0"
 dependencies = [
  "accesskit",
  "bevy_app",
@@ -303,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_animation"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44eae3f1c35a87e38ad146f72317f19ce7616dad8bbdfb88ee752c1282d28c5"
+checksum = "7aa37683b1281e1ba8cf285644e6e3f0704f14b3901c5ee282067ff7ff6f4a56"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -322,9 +384,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_app"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f557a7d59e1e16892d7544fc37316506ee598cb5310ef0365125a30783c11531"
+checksum = "d41731817993f92e4363dd3335558e779e290bc71eefc0b5547052b85810907e"
 dependencies = [
  "bevy_derive",
  "bevy_ecs",
@@ -338,26 +400,29 @@ dependencies = [
 
 [[package]]
 name = "bevy_asset"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9714af523da4cdf58c42a317e5ed40349708ad954a18533991fd64c8ae0a6f68"
+checksum = "935984568f75867dd7357133b06f4b1502cd2be55e4642d483ce597e46e63bff"
 dependencies = [
- "anyhow",
- "async-channel",
+ "async-broadcast",
+ "async-fs",
+ "async-lock 2.8.0",
  "bevy_app",
- "bevy_diagnostic",
+ "bevy_asset_macros",
  "bevy_ecs",
  "bevy_log",
  "bevy_reflect",
  "bevy_tasks",
  "bevy_utils",
  "bevy_winit",
+ "blake3",
  "crossbeam-channel",
  "downcast-rs",
- "fastrand 1.9.0",
+ "futures-io",
+ "futures-lite 1.13.0",
  "js-sys",
- "notify",
  "parking_lot",
+ "ron",
  "serde",
  "thiserror",
  "wasm-bindgen",
@@ -366,12 +431,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "bevy_audio"
-version = "0.11.3"
+name = "bevy_asset_macros"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de308bd63a2f7a0b77ffeb7cf00cc185ec01393c5db2091fe03964f97152749"
+checksum = "3f48b9bbe4ec605e4910b5cd1e1a0acbfbe0b80af5f3bcc4489a9fdd1e80058c"
 dependencies = [
- "anyhow",
+ "bevy_macro_utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
+name = "bevy_audio"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18a69889e1bfa4dbac4e641536b94f91c441da55796ad9832e77836b8264688b"
+dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
@@ -381,15 +457,14 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "oboe",
- "parking_lot",
  "rodio",
 ]
 
 [[package]]
 name = "bevy_core"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d5272321be5fcf5ce2fb16023bc825bb10dfcb71611117296537181ce950f48"
+checksum = "3daa24502a14839509f02407bc7e48299fe84d260877de23b60662de0f4f4b6c"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -402,15 +477,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_core_pipeline"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67382fa9c96ce4f4e5833ed7cedd9886844a8f3284b4a717bd4ac738dcdea0c3"
+checksum = "b4b77c4fca6e90edbe2e72da7bc9aa7aed7dfdfded0920ae0a0c845f5e11084a"
 dependencies = [
  "bevy_app",
  "bevy_asset",
  "bevy_core",
  "bevy_derive",
  "bevy_ecs",
+ "bevy_log",
  "bevy_math",
  "bevy_reflect",
  "bevy_render",
@@ -423,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_derive"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44e4e2784a81430199e4157e02903a987a32127c773985506f020e7d501b62e"
+checksum = "f484318350462c58ba3942a45a656c1fd6b6e484a6b6b7abc3a787ad1a51e500"
 dependencies = [
  "bevy_macro_utils",
  "quote",
@@ -434,9 +510,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_diagnostic"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6babb230dc383c98fdfc9603e3a7a2a49e1e2879dbe8291059ef37dca897932e"
+checksum = "fa38ca5967d335cc1006a0e0f1a86c350e2f15fd1878449f61d04cd57a7c4060"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -449,11 +525,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266144b36df7e834d5198049e037ecdf2a2310a76ce39ed937d1b0a6a2c4e8c6"
+checksum = "7709fbd22f81fb681534cd913c41e1cd18b17143368743281195d7f024b61aea"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "bevy_ecs_macros",
  "bevy_ptr",
  "bevy_reflect",
@@ -470,9 +546,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_ecs_macros"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7157a9c3be038d5008ee3f114feb6cf6b39c1d3d32ee21a7cacb8f81fccdfa80"
+checksum = "a8843aa489f159f25cdcd9fee75cd7d221a7098a71eaa72cb2d6b40ac4e3f1ba"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -482,9 +558,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_encase_derive"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ac0f55ad6bca1be7b0f35bbd5fc95ed3d31e4e9db158fee8e5327f59006001"
+checksum = "5328a3715e933ebbff07d0e99528dc423c4f7a53590ed1ac19a120348b028990"
 dependencies = [
  "bevy_macro_utils",
  "encase_derive_impl",
@@ -492,9 +568,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gilrs"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f4d79c55829f8016014593a42453f61a564ffb06ef79460d25696ccdfac67b"
+checksum = "9b81ca2ebf66cbc7f998f1f142b15038ffe3c4ae1d51f70adda26dcf51b0c4ca"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -508,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_gizmos"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e286a3e7276431963f4aa29165ea5429fa7dbbc6d5c5ba0c531e7dd44ecc88a2"
+checksum = "db232274ddca2ae452eb2731b98267b795d133ddd14013121bc7daddde1c7491"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -528,11 +604,10 @@ dependencies = [
 
 [[package]]
 name = "bevy_gltf"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07494a733dca032e71a20f4b1f423de765da49cbff34406ae6cd813f9b50c41"
+checksum = "85adc6b1fc86687bf67149e0bafaa4d6da432232fa956472d1b37f19121d3ace"
 dependencies = [
- "anyhow",
  "base64 0.13.1",
  "bevy_animation",
  "bevy_app",
@@ -559,9 +634,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_hierarchy"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "103f8f58416ac6799b8c7f0b418f1fac9eba44fa924df3b0e16b09256b897e3d"
+checksum = "06bd477152ce2ae1430f5e0a4f19216e5785c22fee1ab23788b5982dc59d1a55"
 dependencies = [
  "bevy_app",
  "bevy_core",
@@ -574,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_input"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffbd935401101ac8003f3c3aea70788c65ad03f7a32716a10608bedda7a648bc"
+checksum = "cab9a599189b2a694c182d60cd52219dd9364f9892ff542d87799b8e45d9e6dc"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -588,9 +663,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_internal"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e35a9b2bd29aa784b3cc416bcbf2a298f69f00ca51fd042ea39d9af7fad37e"
+checksum = "f124bece9831afd80897815231072d51bfe3ac58c6bb58eca8880963b6d0487c"
 dependencies = [
  "bevy_a11y",
  "bevy_animation",
@@ -627,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_log"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07dcc615ff4f617b06c3f9522fca3c55d56f9644db293318f8ab68fcdea5d4fe"
+checksum = "0dc10ba1d225a8477b9e80a1bf797d8a8b8274e83c9b24fb4d9351aec9229755"
 dependencies = [
  "android_log-sys",
  "bevy_app",
@@ -643,21 +718,22 @@ dependencies = [
 
 [[package]]
 name = "bevy_macro_utils"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ddc18d489b4e57832d4958cde7cd2f349f0ad91e5892ac9e2f2ee16546b981"
+checksum = "e566640c6b6dced73d2006c764c2cffebe1a82be4809486c4a5d7b4b50efed4d"
 dependencies = [
+ "proc-macro2",
  "quote",
  "rustc-hash",
  "syn 2.0.39",
- "toml_edit",
+ "toml_edit 0.20.7",
 ]
 
 [[package]]
 name = "bevy_math"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78286a81fead796dc4b45ab14f4f02fe29a94423d3587bcfef872b2a8e0a474b"
+checksum = "58ddc2b76783939c530178f88e5711a1b01044d7b02db4033e2eb8b43b6cf4ec"
 dependencies = [
  "glam",
  "serde",
@@ -665,18 +741,18 @@ dependencies = [
 
 [[package]]
 name = "bevy_mikktspace"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cfc2a21ea47970a9b1f0f4735af3256a8f204815bd756110051d10f9d909497"
+checksum = "8ec4962977a746d870170532fc92759e04d3dbcae8b7b82e7ca3bb83b1d75277"
 dependencies = [
  "glam",
 ]
 
 [[package]]
 name = "bevy_pbr"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ca796a619e61cd43a0a3b11fde54644f7f0732a1fba1eef5d406248c6eba85"
+checksum = "520bfd2a898c74f84ea52cfb8eb061f37373ad15e623489d5f75d27ebd6138fe"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -691,21 +767,24 @@ dependencies = [
  "bevy_window",
  "bitflags 2.4.1",
  "bytemuck",
+ "fixedbitset",
  "naga_oil",
  "radsort",
+ "smallvec",
+ "thread_local",
 ]
 
 [[package]]
 name = "bevy_ptr"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c7586401a46f7d8e436028225c1df5288f2e0082d066b247a82466fea155c6"
+checksum = "c77ec20c8fafcdc196508ef5ccb4f0400a8d193cb61f7b14a36ed9a25ad423cf"
 
 [[package]]
 name = "bevy_reflect"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0778197a1eb3e095a71417c74b7152ede02975cdc95b5ea4ddc5251ed00a2eb5"
+checksum = "d7921f15fc944c9c8ad01d7dbcea6505b8909c6655cd9382bab1407181556038"
 dependencies = [
  "bevy_math",
  "bevy_ptr",
@@ -714,8 +793,6 @@ dependencies = [
  "downcast-rs",
  "erased-serde",
  "glam",
- "once_cell",
- "parking_lot",
  "serde",
  "smallvec",
  "smol_str",
@@ -724,12 +801,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_reflect_derive"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "342a4b2d09db22c48607d23ad59a056aff1ee004549050a51d490d375ba29528"
+checksum = "b4a8c5475f216e751ef4452a1306b00711f33d2d04d9f149e4c845dfeb6753a0"
 dependencies = [
  "bevy_macro_utils",
- "bit-set",
  "proc-macro2",
  "quote",
  "syn 2.0.39",
@@ -738,12 +814,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_render"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df4824b760928c27afc7b00fb649c7a63c9d76661ab014ff5c86537ee906cb"
+checksum = "bdefdd3737125b0d94a6ff20bb70fa8cfe9d7d5dcd72ba4dfe6c5f1d30d9f6e4"
 dependencies = [
- "anyhow",
- "async-channel",
+ "async-channel 1.9.0",
  "bevy_app",
  "bevy_asset",
  "bevy_core",
@@ -773,8 +848,6 @@ dependencies = [
  "ktx2",
  "naga",
  "naga_oil",
- "parking_lot",
- "regex",
  "ruzstd",
  "serde",
  "smallvec",
@@ -783,14 +856,13 @@ dependencies = [
  "wasm-bindgen",
  "web-sys",
  "wgpu",
- "wgpu-hal",
 ]
 
 [[package]]
 name = "bevy_render_macros"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd08c740aac73363e32fb45af869b10cec65bcb76fe3e6cd0f8f7eebf4c36c9"
+checksum = "64d86bfc5a1e7fbeeaec0c4ceab18155530f5506624670965db3415f75826bea"
 dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
@@ -800,11 +872,10 @@ dependencies = [
 
 [[package]]
 name = "bevy_scene"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd47e1263506153bef3a8be97fe2d856f206d315668c4f97510ca6cc181d9681"
+checksum = "e7df078b5e406e37c8a1c6ba0d652bf105fde713ce3c3efda7263fe27467eee5"
 dependencies = [
- "anyhow",
  "bevy_app",
  "bevy_asset",
  "bevy_derive",
@@ -822,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_sprite"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a8ca824fad75c6ef74cfbbba0a4ce3ccc435fa23d6bf3f003f260548813397"
+checksum = "c7cc0c9d946e17e3e0aaa202f182837bc796c4f862b2e5a805134f873f21cf7f"
 dependencies = [
  "bevy_app",
  "bevy_asset",
@@ -841,17 +912,18 @@ dependencies = [
  "bytemuck",
  "fixedbitset",
  "guillotiere",
+ "radsort",
  "rectangle-pack",
  "thiserror",
 ]
 
 [[package]]
 name = "bevy_tasks"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c73bbb847c83990d3927005090df52f8ac49332e1643d2ad9aac3cd2974e66bf"
+checksum = "f4fefa7fe0da8923525f7500e274f1bd60dbd79918a25cf7d0dfa0a6ba15c1cf"
 dependencies = [
- "async-channel",
+ "async-channel 1.9.0",
  "async-executor",
  "async-task",
  "concurrent-queue",
@@ -861,12 +933,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_text"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692288ab7b0a9f8b38058964c52789fc6bcb63703b23de51cce90ec41bfca355"
+checksum = "3a9a79d49ca06170d69149949b134c14e8b99ace1444c1ca2cd4743b19d5b055"
 dependencies = [
  "ab_glyph",
- "anyhow",
  "bevy_app",
  "bevy_asset",
  "bevy_ecs",
@@ -884,9 +955,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_time"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d58d6dbae9c8225d8c0e0f04d2c5dbb71d22adc01ecd5ab3cebc364139e4a6d"
+checksum = "e6250d76eed3077128b6a3d004f9f198b01107800b9824051e32bb658054e837"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
@@ -898,22 +969,23 @@ dependencies = [
 
 [[package]]
 name = "bevy_transform"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9b0ac0149a57cd846cb357a35fc99286f9848e53d4481954608ac9552ed2d4"
+checksum = "d541e0c292edbd96afae816ee680e02247422423ccd5dc635c1e211a20ed64be"
 dependencies = [
  "bevy_app",
  "bevy_ecs",
  "bevy_hierarchy",
  "bevy_math",
  "bevy_reflect",
+ "thiserror",
 ]
 
 [[package]]
 name = "bevy_ui"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b6d295a755e5b79e869a09e087029d72974562a521ec7ccfba7141fa948a32"
+checksum = "d785e3b75dabcb2a8ad0d50933f8f3446d59e512cabc2d2a145e28c2bb8792ba"
 dependencies = [
  "bevy_a11y",
  "bevy_app",
@@ -941,15 +1013,16 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d9484e32434ea84dc548cff246ce0c6f756c1336f5ea03f24ac120a48595c7"
+checksum = "7915222f4a08ccc782e08d10b751b42e5f9d786e697d0cb3fd09333cb7e8b6ea"
 dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
  "getrandom",
  "hashbrown 0.14.3",
  "instant",
+ "nonmax",
  "petgraph",
  "thiserror",
  "tracing",
@@ -958,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_utils_proc_macros"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5391b242c36f556db01d5891444730c83aa9dd648b6a8fd2b755d22cb3bddb57"
+checksum = "7aafecc952b6b8eb1a93c12590bd867d25df2f4ae1033a01dfdfc3c35ebccfff"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -969,10 +1042,11 @@ dependencies = [
 
 [[package]]
 name = "bevy_window"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd584c0da7c4ada6557b09f57f30fb7cff21ccedc641473fc391574b4c9b7944"
+checksum = "41ee72bf7f974000e9b31bb971a89387f1432ba9413f35c4fef59fef49767260"
 dependencies = [
+ "bevy_a11y",
  "bevy_app",
  "bevy_ecs",
  "bevy_input",
@@ -984,9 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "bevy_winit"
-version = "0.11.3"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdc044abdb95790c20053e6326760f0a2985f0dcd78613d397bf35f16039d53"
+checksum = "1eb71f287eca9006dda998784c7b931e400ae2cc4c505da315882a8b082f21ad"
 dependencies = [
  "accesskit_winit",
  "approx",
@@ -1058,6 +1132,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0231f06152bf547e9c2b5194f247cd97aacf6dcd8b15d8e5ec0663f64580da87"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1167,22 @@ checksum = "8dd9e63c1744f755c2f60332b88de39d341e5e86239014ad839bd71c106dec42"
 dependencies = [
  "block-sys",
  "objc2-encode",
+]
+
+[[package]]
+name = "blocking"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
+dependencies = [
+ "async-channel 2.1.1",
+ "async-lock 3.1.2",
+ "async-task",
+ "fastrand 2.0.1",
+ "futures-io",
+ "futures-lite 2.0.1",
+ "piper",
+ "tracing",
 ]
 
 [[package]]
@@ -1232,6 +1335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87ca1caa64ef4ed453e68bb3db612e51cf1b2f5b871337f0fcab1c8f87cc3dff"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+
+[[package]]
 name = "constgebra"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,8 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "constructivism_macro_gen"
-version = "0.1.0"
-source = "git+https://github.com/polako-rs/constructivism#a4ecfac04bbac36fd50f442ea8ed13e48bdf3bf8"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d99bf6c312c49ad6bb853e658f5a51543b2d11e117e88fd100e03cbebadbe22"
 dependencies = [
  "quote",
  "syn 2.0.39",
@@ -1251,8 +1361,9 @@ dependencies = [
 
 [[package]]
 name = "constructivist"
-version = "0.0.1"
-source = "git+https://github.com/polako-rs/constructivism#a4ecfac04bbac36fd50f442ea8ed13e48bdf3bf8"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b234754b61a36e3d5355ff13f56b18faef3623a344eac6b1e4a8e9bd29a5ce5"
 dependencies = [
  "constructivism_macro_gen",
  "proc-macro2",
@@ -1286,7 +1397,7 @@ dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
 ]
 
@@ -1376,12 +1487,12 @@ dependencies = [
 
 [[package]]
 name = "d3d12"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8f0de2f5a8e7bd4a9eec0e3c781992a4ce1724f68aec7d7a3715344de8b39da"
+checksum = "e16e44ab292b1dddfdaf7be62cfd8877df52f2f3fde5858d95bab606be259f20"
 dependencies = [
- "bitflags 1.3.2",
- "libloading 0.7.4",
+ "bitflags 2.4.1",
+ "libloading 0.8.1",
  "winapi",
 ]
 
@@ -1396,6 +1507,12 @@ name = "data-encoding"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+
+[[package]]
+name = "data-url"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7439c3735f405729d52c3fbbe4de140eaf938a1fe47d227c27f8254d4302a5"
 
 [[package]]
 name = "dispatch"
@@ -1517,15 +1634,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "filetime"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+name = "fello"
+version = "0.1.0"
+source = "git+https://github.com/dfrg/fount?rev=dadbcf75695f035ca46766bfd60555d05bd421b1#dadbcf75695f035ca46766bfd60555d05bd421b1"
 dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall 0.3.5",
- "windows-sys 0.48.0",
+ "read-fonts",
 ]
 
 [[package]]
@@ -1545,10 +1658,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "font-types"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978d65d61022aa249fefdd914dc8215757f617f1a697c496ef6b42013366567"
+
+[[package]]
+name = "fontconfig-parser"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674e258f4b5d2dcd63888c01c68413c51f565e8af99d2f7701c7b81d79ef41c4"
+dependencies = [
+ "roxmltree",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8d8cbea8f21307d7e84bca254772981296f058a1d36b461bf4d83a7499fc9e"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.19.2",
+]
 
 [[package]]
 name = "foreign-types"
@@ -1556,7 +1704,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1566,19 +1735,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
-name = "fsevent-sys"
-version = "4.1.0"
+name = "foreign-types-shared"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "futures-core"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
 
 [[package]]
 name = "futures-io"
@@ -1648,7 +1825,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "178769da179a47b187837d1ab2b5b9b684a21180166a77a4ca37e7e58ee3833d"
 dependencies = [
  "core-foundation",
- "inotify 0.10.2",
+ "inotify",
  "io-kit-sys",
  "js-sys",
  "libc",
@@ -1744,21 +1921,21 @@ dependencies = [
 
 [[package]]
 name = "gpu-alloc"
-version = "0.5.4"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22beaafc29b38204457ea030f6fb7a84c9e4dd1b86e311ba0542533453d87f62"
+checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "gpu-alloc-types",
 ]
 
 [[package]]
 name = "gpu-alloc-types"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54804d0d6bc9d7f26db4eaec1ad10def69b599315f487d32c334a80d1efe67a5"
+checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
 ]
 
 [[package]]
@@ -1873,6 +2050,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "imagesize"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1897,17 +2080,6 @@ name = "inflections"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
-
-[[package]]
-name = "inotify"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
-dependencies = [
- "bitflags 1.3.2",
- "inotify-sys",
- "libc",
-]
 
 [[package]]
 name = "inotify"
@@ -2021,32 +2193,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "kqueue"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7447f1ca1b7b563588a205fe93dea8df60fd981423a768bc1c0ded35ed147d0c"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
-dependencies = [
- "bitflags 1.3.2",
- "libc",
-]
-
-[[package]]
 name = "ktx2"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87d65e08a9ec02e409d27a0139eaa6b9756b4d81fe7cde71f6941a83730ce838"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd85a5776cd9500c2e2059c8c76c3b01528566b7fcbaf8098b55a33fc298849b"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "kurbo"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1618d4ebd923e97d67e7cd363d80aef35fe961005cbbbb3d2dad8bdd1bc63440"
+dependencies = [
+ "arrayvec",
+ "smallvec",
 ]
 
 [[package]]
@@ -2169,17 +2340,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
-name = "metal"
-version = "0.24.0"
+name = "memmap2"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de11355d1f6781482d027a3b4d4de7825dcedb197bf573e0596d00008402d060"
+checksum = "6d28bba84adfe6646737845bc5ebbfa2c08424eb1c37e94a1fd2a82adb56a872"
 dependencies = [
- "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "metal"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "623b5e6cefd76e58f774bd3cc0c6f5c7615c58c03a97815245a25c3c9bdee318"
+dependencies = [
+ "bitflags 2.4.1",
  "block",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "log",
  "objc",
+ "paste",
 ]
 
 [[package]]
@@ -2212,12 +2393,12 @@ dependencies = [
 
 [[package]]
 name = "naga"
-version = "0.12.3"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbcc2e0513220fd2b598e6068608d4462db20322c0e77e47f6f488dfcfc279cb"
+checksum = "c1ceaaa4eedaece7e4ec08c55c640ba03dbb73fb812a6570a59bcf1930d0f70e"
 dependencies = [
  "bit-set",
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "codespan-reporting",
  "hexf-parse",
  "indexmap 1.9.3",
@@ -2233,9 +2414,9 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.8.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be942a5c21c58b9b0bf4d9b99db3634ddb7a916f8e1d1d0b71820cc4150e56b"
+checksum = "4ac54c77b3529887f9668d3dd81e955e58f252b31a333f836e3548c06460b958"
 dependencies = [
  "bit-set",
  "codespan-reporting",
@@ -2244,7 +2425,7 @@ dependencies = [
  "naga",
  "once_cell",
  "regex",
- "regex-syntax 0.6.29",
+ "regex-syntax 0.7.5",
  "rustc-hash",
  "thiserror",
  "tracing",
@@ -2313,23 +2494,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "notify"
-version = "6.1.1"
+name = "nonmax"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
-dependencies = [
- "bitflags 2.4.1",
- "crossbeam-channel",
- "filetime",
- "fsevent-sys",
- "inotify 0.9.6",
- "kqueue",
- "libc",
- "log",
- "mio",
- "walkdir",
- "windows-sys 0.48.0",
-]
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
 
 [[package]]
 name = "ntapi"
@@ -2546,7 +2714,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
 dependencies = [
- "ttf-parser",
+ "ttf-parser 0.20.0",
 ]
 
 [[package]]
@@ -2591,6 +2759,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "peniko"
+version = "0.1.0"
+source = "git+https://github.com/linebender/peniko?rev=629fc3325b016a8c98b1cd6204cb4ddf1c6b3daa#629fc3325b016a8c98b1cd6204cb4ddf1c6b3daa"
+dependencies = [
+ "kurbo 0.10.4",
+ "smallvec",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2607,10 +2784,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+
+[[package]]
+name = "piper"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+dependencies = [
+ "atomic-waker",
+ "fastrand 2.0.1",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -2641,6 +2835,14 @@ dependencies = [
  "polako_flow",
  "polako_input",
  "polako_macro",
+ "polako_ui",
+]
+
+[[package]]
+name = "polako_channel"
+version = "0.1.0"
+dependencies = [
+ "bevy",
 ]
 
 [[package]]
@@ -2675,6 +2877,7 @@ name = "polako_flow"
 version = "0.1.0"
 dependencies = [
  "bevy",
+ "polako_channel",
  "polako_constructivism",
  "polako_input",
 ]
@@ -2700,6 +2903,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "polako_ui"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "bevy-vello",
+ "peniko",
+ "polako_channel",
+ "taffy",
+ "vello",
+]
+
+[[package]]
 name = "pp-rs"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2715,7 +2930,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -2759,6 +2974,21 @@ name = "raw-window-handle"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
+
+[[package]]
+name = "rctree"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b42e27ef78c35d3998403c1d26f3efd9e135d3e5121b0a4845cc5cc27547f4f"
+
+[[package]]
+name = "read-fonts"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d08214643b2df95b0b3955cd9f264bcfab22b73470b83df4992df523b4d6eb"
+dependencies = [
+ "font-types",
+]
 
 [[package]]
 name = "rectangle-pack"
@@ -2824,6 +3054,12 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+
+[[package]]
+name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
@@ -2857,6 +3093,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rosvgtree"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad747e7384940e7bf33b15ba433b7bad9f44c0c6d5287a67c2cb22cd1743d497"
+dependencies = [
+ "log",
+ "roxmltree",
+ "simplecss",
+ "siphasher",
+ "svgtypes",
+]
+
+[[package]]
+name = "roxmltree"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +3125,22 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustybuzz"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162bdf42e261bee271b3957691018634488084ef577dddeb6420a9684cab2a6a"
+dependencies = [
+ "bitflags 1.3.2",
+ "bytemuck",
+ "smallvec",
+ "ttf-parser 0.18.1",
+ "unicode-bidi-mirroring",
+ "unicode-ccc",
+ "unicode-general-category",
+ "unicode-script",
+]
 
 [[package]]
 name = "ruzstd"
@@ -2932,6 +3206,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,6 +3245,21 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simplecss"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11be7c62927d9427e9f40f3444d5499d868648e2edbc4e2116de69e7ec0e89d"
+dependencies = [
+ "log",
+]
+
+[[package]]
+name = "siphasher"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
@@ -3014,10 +3314,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strict-num"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+dependencies = [
+ "float-cmp",
+]
+
+[[package]]
 name = "svg_fmt"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fb1df15f412ee2e9dfc1c504260fa695c1c3f10fe9f4a6ee2d2184d7d6450e2"
+
+[[package]]
+name = "svgtypes"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed4b0611e7f3277f68c0fa18e385d9e2d26923691379690039548f867cef02a7"
+dependencies = [
+ "kurbo 0.9.5",
+ "siphasher",
+]
 
 [[package]]
 name = "syn"
@@ -3150,7 +3469,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -3171,6 +3490,17 @@ dependencies = [
  "indexmap 2.1.0",
  "serde",
  "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.20.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
+dependencies = [
+ "indexmap 2.1.0",
  "toml_datetime",
  "winnow",
 ]
@@ -3260,6 +3590,18 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0609f771ad9c6155384897e1df4d948e692667cc0588548b68eb44d052b27633"
+
+[[package]]
+name = "ttf-parser"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
+
+[[package]]
+name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
@@ -3275,10 +3617,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+
+[[package]]
+name = "unicode-bidi-mirroring"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d12260fb92d52f9008be7e4bca09f584780eb2266dc8fecc6a192bec561694"
+
+[[package]]
+name = "unicode-ccc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2520efa644f8268dce4dcd3050eaa7fc044fca03961e9998ac7e2e92b77cf1"
+
+[[package]]
+name = "unicode-general-category"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2281c8c1d221438e373249e065ca4989c4c36952c211ff21a0ee91c44a3869e7"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-script"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d817255e1bed6dfd4ca47258685d14d2bdcfbc64fdc9e3819bd5848057b8ecc"
+
+[[package]]
+name = "unicode-vo"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d386ff53b415b7fe27b50bb44679e2cc4660272694b7b6f3326d8480823a94"
 
 [[package]]
 name = "unicode-width"
@@ -3291,6 +3669,66 @@ name = "unicode-xid"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "usvg"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae32eb823aab35fc343b19c4d354f70e713b442ce34cdfa8497bf6c39af8a342"
+dependencies = [
+ "base64 0.21.5",
+ "log",
+ "pico-args",
+ "usvg-parser",
+ "usvg-text-layout",
+ "usvg-tree",
+ "xmlwriter",
+]
+
+[[package]]
+name = "usvg-parser"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7529174e721c8078d62b08399258469b1d68b4e5f2983b347d6a9d39779366c"
+dependencies = [
+ "data-url",
+ "flate2",
+ "imagesize",
+ "kurbo 0.9.5",
+ "log",
+ "rosvgtree",
+ "strict-num",
+ "svgtypes",
+ "usvg-tree",
+]
+
+[[package]]
+name = "usvg-text-layout"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e672fbc19261c6553113cc04ff2ff38ae52fadbd90f2d814040857795fb5c50"
+dependencies = [
+ "fontdb",
+ "kurbo 0.9.5",
+ "log",
+ "rustybuzz",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "usvg-tree",
+]
+
+[[package]]
+name = "usvg-tree"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a56e9cd3be5eb6d6744477e95b82d52d393fc1dba4b5b090912c33af337c20b"
+dependencies = [
+ "kurbo 0.9.5",
+ "rctree",
+ "strict-num",
+ "svgtypes",
+]
 
 [[package]]
 name = "uuid"
@@ -3313,6 +3751,56 @@ name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "vello"
+version = "0.0.1"
+source = "git+https://github.com/linebender/vello?rev=28914d66f675efecf03c53261a0fb1b8ecce4fe9#28914d66f675efecf03c53261a0fb1b8ecce4fe9"
+dependencies = [
+ "bytemuck",
+ "fello",
+ "futures-intrusive",
+ "kurbo 0.10.4",
+ "peniko",
+ "raw-window-handle",
+ "vello_encoding",
+ "wgpu",
+]
+
+[[package]]
+name = "vello-svg"
+version = "0.1.0"
+source = "git+https://github.com/vectorgameexperts/vello-svg#73b06d6ac17e838cad0db3eef5e435bb77096253"
+dependencies = [
+ "log",
+ "usvg",
+ "vello",
+]
+
+[[package]]
+name = "vello_encoding"
+version = "0.1.0"
+source = "git+https://github.com/linebender/vello?rev=28914d66f675efecf03c53261a0fb1b8ecce4fe9#28914d66f675efecf03c53261a0fb1b8ecce4fe9"
+dependencies = [
+ "bytemuck",
+ "fello",
+ "guillotiere",
+ "peniko",
+]
+
+[[package]]
+name = "vellottie"
+version = "0.1.0"
+source = "git+https://github.com/vectorgameexperts/vellottie#e32666669b849b91fb6783485f9d770fce4e54f6"
+dependencies = [
+ "lazy_static",
+ "log",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "thiserror",
+ "vello",
+]
 
 [[package]]
 name = "version_check"
@@ -3431,9 +3919,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu"
-version = "0.16.3"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "480c965c9306872eb6255fa55e4b4953be55a8b64d57e61d7ff840d3dcc051cd"
+checksum = "752e44d3998ef35f71830dd1ad3da513e628e2e4d4aedb0ab580f850827a0b41"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -3455,9 +3943,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.16.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
+checksum = "0f8a44dd301a30ceeed3c27d8c0090433d3da04d7b2a4042738095a424d12ae7"
 dependencies = [
  "arrayvec",
  "bit-vec",
@@ -3478,9 +3966,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.16.2"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecb3258078e936deee14fd4e0febe1cfe9bbb5ffef165cb60218d2ee5eb4448"
+checksum = "9a80bf0e3c77399bb52850cb0830af9bad073d5cfcb9dd8253bef8125c42db17"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -3490,7 +3978,6 @@ dependencies = [
  "block",
  "core-graphics-types",
  "d3d12",
- "foreign-types",
  "glow",
  "gpu-alloc",
  "gpu-allocator",
@@ -3520,9 +4007,9 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c153280bb108c2979eb5c7391cb18c56642dd3c072e55f52065e13e2a1252a"
+checksum = "ee64d7398d0c2f9ca48922c902ef69c42d000c759f3db41e355f4a570b052b67"
 dependencies = [
  "bitflags 2.4.1",
  "js-sys",
@@ -3829,6 +4316,18 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xmlwriter"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ checksum = "a44e4e2784a81430199e4157e02903a987a32127c773985506f020e7d501b62e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -474,7 +474,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -646,7 +646,7 @@ checksum = "23ddc18d489b4e57832d4958cde7cd2f349f0ad91e5892ac9e2f2ee16546b981"
 dependencies = [
  "quote",
  "rustc-hash",
- "syn 2.0.37",
+ "syn 2.0.38",
  "toml_edit",
 ]
 
@@ -729,7 +729,7 @@ dependencies = [
  "bit-set",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "uuid",
 ]
 
@@ -792,7 +792,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -961,7 +961,7 @@ checksum = "5391b242c36f556db01d5891444730c83aa9dd648b6a8fd2b755d22cb3bddb57"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1021,7 +1021,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1102,7 +1102,7 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1243,7 +1243,7 @@ version = "0.1.0"
 source = "git+https://github.com/polako-rs/constructivism#d7ec940b32963399b714348df3941d9750e1e411"
 dependencies = [
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1254,7 +1254,7 @@ dependencies = [
  "constructivism_macro_gen",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "toml",
 ]
 
@@ -1441,7 +1441,7 @@ checksum = "3fe2568f851fd6144a45fa91cfed8fe5ca8fc0b56ba6797bfc1ed2771b90e37c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -1683,7 +1683,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2375,7 +2375,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ dependencies = [
  "constructivist",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "toml",
 ]
 
@@ -2645,9 +2645,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.67"
+version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
+checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
 dependencies = [
  "unicode-ident",
 ]
@@ -2833,7 +2833,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -2948,9 +2948,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.37"
+version = "2.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
+checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3029,7 +3029,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3111,7 +3111,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
 ]
 
 [[package]]
@@ -3269,7 +3269,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-shared",
 ]
 
@@ -3303,7 +3303,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn 2.0.38",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "ab_glyph"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1061f3ff92c2f65800df1f12fc7b4ff44ee14783104187dd04dfee6f11b0fd2"
+checksum = "80179d7dd5d7e8c285d67c4a1e652972a92de7475beddfb92028c76463b13225"
 dependencies = [
  "ab_glyph_rasterizer",
  "owned_ttf_parser",
@@ -88,21 +88,22 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "91429305e9f0a25f6205c5b8e0d2db09e0708a7a6df0f42212bb56c32c8ac97a"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5d730647d4fadd988536d06fecce94b7b4f2a7efdae548f1cf4b63205518ab"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
  "memchr",
 ]
@@ -211,38 +212,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
 dependencies = [
  "concurrent-queue",
- "event-listener",
+ "event-listener 2.5.3",
  "futures-core",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.5.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c1da3ae8dabd9c00f453a329dfe1fb28da3c0a72e2478cdcd93171740c20499"
+checksum = "17ae5ebefcc48e7452b4987947920dac9450be1110cadf34d1b8c116bdbaf97c"
 dependencies = [
  "async-lock",
  "async-task",
  "concurrent-queue",
  "fastrand 2.0.1",
- "futures-lite",
+ "futures-lite 2.0.1",
  "slab",
 ]
 
 [[package]]
 name = "async-lock"
-version = "2.8.0"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
+checksum = "dea8b3453dd7cc96711834b75400d671b73e3656975fa68d9f277163b7f7e316"
 dependencies = [
- "event-listener",
+ "event-listener 4.0.0",
+ "event-listener-strategy",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "async-task"
-version = "4.4.1"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9441c6b2fe128a7c2bf680a44c34d0df31ce09e5b7e401fcca3faa483dbc921"
+checksum = "b4eb2cdb97421e01129ccb49169d8279ed21e829929144f4a22a6e54ac549ca1"
 
 [[package]]
 name = "autocfg"
@@ -273,9 +276,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.4"
+version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
 
 [[package]]
 name = "bevy"
@@ -413,7 +416,7 @@ dependencies = [
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "radsort",
  "serde",
 ]
@@ -426,7 +429,7 @@ checksum = "a44e4e2784a81430199e4157e02903a987a32127c773985506f020e7d501b62e"
 dependencies = [
  "bevy_macro_utils",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -457,7 +460,7 @@ dependencies = [
  "bevy_tasks",
  "bevy_utils",
  "downcast-rs",
- "event-listener",
+ "event-listener 2.5.3",
  "fixedbitset",
  "rustc-hash",
  "serde",
@@ -474,7 +477,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -633,7 +636,7 @@ dependencies = [
  "bevy_ecs",
  "bevy_utils",
  "console_error_panic_hook",
- "tracing-log",
+ "tracing-log 0.1.4",
  "tracing-subscriber",
  "tracing-wasm",
 ]
@@ -646,7 +649,7 @@ checksum = "23ddc18d489b4e57832d4958cde7cd2f349f0ad91e5892ac9e2f2ee16546b981"
 dependencies = [
  "quote",
  "rustc-hash",
- "syn 2.0.38",
+ "syn 2.0.39",
  "toml_edit",
 ]
 
@@ -686,7 +689,7 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bytemuck",
  "naga_oil",
  "radsort",
@@ -729,7 +732,7 @@ dependencies = [
  "bit-set",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "uuid",
 ]
 
@@ -758,12 +761,12 @@ dependencies = [
  "bevy_transform",
  "bevy_utils",
  "bevy_window",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bytemuck",
  "codespan-reporting",
  "downcast-rs",
  "encase",
- "futures-lite",
+ "futures-lite 1.13.0",
  "hexasphere",
  "image",
  "js-sys",
@@ -792,7 +795,7 @@ dependencies = [
  "bevy_macro_utils",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -834,7 +837,7 @@ dependencies = [
  "bevy_render",
  "bevy_transform",
  "bevy_utils",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "bytemuck",
  "fixedbitset",
  "guillotiere",
@@ -852,7 +855,7 @@ dependencies = [
  "async-executor",
  "async-task",
  "concurrent-queue",
- "futures-lite",
+ "futures-lite 1.13.0",
  "wasm-bindgen-futures",
 ]
 
@@ -945,7 +948,7 @@ dependencies = [
  "ahash",
  "bevy_utils_proc_macros",
  "getrandom",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
  "instant",
  "petgraph",
  "thiserror",
@@ -961,7 +964,7 @@ checksum = "5391b242c36f556db01d5891444730c83aa9dd648b6a8fd2b755d22cb3bddb57"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1006,11 +1009,11 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.69.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "9ffcebc3849946a7170a05992aac39da343a90676ab392c51a4280981d6379c2"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -1021,7 +1024,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1047,9 +1050,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 dependencies = [
  "serde",
 ]
@@ -1102,14 +1105,14 @@ checksum = "965ab7eb5f8f97d2a083c799f3a1b994fc397b2fe2da5d1da1626ce15a39f2b1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -1240,21 +1243,21 @@ dependencies = [
 [[package]]
 name = "constructivism_macro_gen"
 version = "0.1.0"
-source = "git+https://github.com/polako-rs/constructivism#0e36fffa34d956bb4841ff574a3294866c9afa21"
+source = "git+https://github.com/polako-rs/constructivism#a4ecfac04bbac36fd50f442ea8ed13e48bdf3bf8"
 dependencies = [
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "constructivist"
 version = "0.0.1"
-source = "git+https://github.com/polako-rs/constructivism#0e36fffa34d956bb4841ff574a3294866c9afa21"
+source = "git+https://github.com/polako-rs/constructivism#a4ecfac04bbac36fd50f442ea8ed13e48bdf3bf8"
 dependencies = [
  "constructivism_macro_gen",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "toml",
 ]
 
@@ -1264,15 +1267,9 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
 dependencies = [
- "core-foundation-sys 0.8.4",
+ "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ca8a5221364ef15ce201e8ed2f609fc312682a8f4e0e3d4aa5879764e0fa3b"
 
 [[package]]
 name = "core-foundation-sys"
@@ -1306,20 +1303,20 @@ dependencies = [
 
 [[package]]
 name = "coreaudio-rs"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb17e2d1795b1996419648915df94bc7103c28f7b48062d7acf4652fc371b2ff"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation-sys 0.6.2",
+ "core-foundation-sys",
  "coreaudio-sys",
 ]
 
 [[package]]
 name = "coreaudio-sys"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8478e5bdad14dce236b9898ea002eabfa87cbe14f0aa538dbe3b6a4bec4332d"
+checksum = "f3120ebb80a9de008e638ad833d4127d50ea3d3a960ea23ea69bc66d9358a028"
 dependencies = [
  "bindgen",
 ]
@@ -1331,7 +1328,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d959d90e938c5493000514b446987c07aed46c668faaa7d34d6c7a67b1a578c"
 dependencies = [
  "alsa",
- "core-foundation-sys 0.8.4",
+ "core-foundation-sys",
  "coreaudio-rs",
  "dasp_sample",
  "jni 0.19.0",
@@ -1396,9 +1393,9 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "dispatch"
@@ -1441,7 +1438,7 @@ checksum = "3fe2568f851fd6144a45fa91cfed8fe5ca8fc0b56ba6797bfc1ed2771b90e37c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1475,6 +1472,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
+name = "event-listener"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "770d968249b5d99410d61f5bf89057f3199a077a04d087092f58e7d10692baae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
+dependencies = [
+ "event-listener 4.0.0",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1491,9 +1509,9 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+checksum = "64d6dafc854908ff5da46ff3f8f473c6984119a2876a383a860246dd7841a868"
 dependencies = [
  "simd-adler32",
 ]
@@ -1506,7 +1524,7 @@ checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "windows-sys 0.48.0",
 ]
 
@@ -1518,9 +1536,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1558,15 +1576,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
 
 [[package]]
 name = "futures-lite"
@@ -1584,10 +1602,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.10"
+name = "futures-lite"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "d3831c2651acb5177cbd83943f3d9c8912c5ad03c76afcc0e9511ba568ec5ebb"
+dependencies = [
+ "fastrand 2.0.1",
+ "futures-core",
+ "futures-io",
+ "memchr",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1598,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "gilrs"
-version = "0.10.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fd19844d0eb919aca41d3e4ea0e0b6bf60e1e827558b101c269015b8f5f27a"
+checksum = "9e9eec02069fcbd7abe00a28adf216547774889129a777cb5e53fdfb75d59f09"
 dependencies = [
  "fnv",
  "gilrs-core",
@@ -1611,17 +1643,18 @@ dependencies = [
 
 [[package]]
 name = "gilrs-core"
-version = "0.5.7"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccc99e9b8d63ffcaa334c4babfa31f46e156618a11f63efb6e8e6bcb37b830d"
+checksum = "178769da179a47b187837d1ab2b5b9b684a21180166a77a4ca37e7e58ee3833d"
 dependencies = [
  "core-foundation",
+ "inotify 0.10.2",
  "io-kit-sys",
  "js-sys",
  "libc",
  "libudev-sys",
  "log",
- "nix 0.26.4",
+ "nix 0.27.1",
  "uuid",
  "vec_map",
  "wasm-bindgen",
@@ -1631,9 +1664,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.0"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glam"
@@ -1683,7 +1716,7 @@ dependencies = [
  "inflections",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -1747,9 +1780,9 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "gpu-descriptor-types",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1758,7 +1791,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
 ]
 
 [[package]]
@@ -1785,9 +1818,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 dependencies = [
  "ahash",
  "allocator-api2",
@@ -1851,12 +1884,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.1",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1870,6 +1903,17 @@ name = "inotify"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
 dependencies = [
  "bitflags 1.3.2",
  "inotify-sys",
@@ -1899,11 +1943,11 @@ dependencies = [
 
 [[package]]
 name = "io-kit-sys"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2d4429acc1deff0fbdece0325b4997bdb02b2c245ab7023fd5deca0f6348de"
+checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
 dependencies = [
- "core-foundation-sys 0.8.4",
+ "core-foundation-sys",
  "mach2",
 ]
 
@@ -1949,18 +1993,18 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+checksum = "8c37f63953c4c63420ed5fd3d6d398c719489b9f872b9fa683262f8edd363c7d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "cee9c64da59eae3b50095c18d3e74f8b73c0b86d2792824ff01bbce68ba229ca"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2030,9 +2074,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.148"
+version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
+checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
 
 [[package]]
 name = "libloading"
@@ -2055,6 +2099,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
+dependencies = [
+ "bitflags 2.4.1",
+ "libc",
+ "redox_syscall 0.4.1",
+]
+
+[[package]]
 name = "libudev-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,9 +2121,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2145,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "3dce281c5e46beae905d4de1870d8b1509a9142b62eedf18b443b011ca8343d0"
 dependencies = [
  "libc",
  "log",
@@ -2238,11 +2293,11 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.4.1",
  "cfg-if",
  "libc",
 ]
@@ -2263,11 +2318,11 @@ version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "crossbeam-channel",
  "filetime",
  "fsevent-sys",
- "inotify",
+ "inotify 0.9.6",
  "kqueue",
  "libc",
  "log",
@@ -2329,9 +2384,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
 dependencies = [
  "autocfg",
 ]
@@ -2375,7 +2430,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -2472,11 +2527,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "orbclient"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8378ac0dfbd4e7895f2d2c1f1345cab3836910baf3a300b000d04250f0c8428f"
+checksum = "52f0d54bde9774d3a51dcf281a5def240c71996bc6ca05d2c847ec8b2b216166"
 dependencies = [
- "redox_syscall",
+ "libredox",
 ]
 
 [[package]]
@@ -2487,18 +2542,18 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owned_ttf_parser"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "706de7e2214113d63a8238d1910463cfce781129a6f263d13fdb09ff64355ba4"
+checksum = "d4586edfe4c648c71797a74c84bacb32b52b212eff5dfe2bb9f2c599844023e7"
 dependencies = [
  "ttf-parser",
 ]
 
 [[package]]
 name = "parking"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e52c774a4c39359c1d1c52e43f73dd91a75a614652c825408eec30c95a9b2067"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -2512,13 +2567,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -2537,9 +2592,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -2548,7 +2603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
 ]
 
 [[package]]
@@ -2640,7 +2695,7 @@ dependencies = [
  "constructivist",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "toml",
 ]
 
@@ -2665,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.68"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1106fec09662ec6dd98ccac0f81cef56984d0b49f75c92d8cbad76e20c005c"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -2721,15 +2776,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.9.6"
+name = "redox_syscall"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.3.9",
- "regex-syntax 0.7.5",
+ "regex-automata 0.4.3",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2743,13 +2807,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.9"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.7.5",
+ "regex-syntax 0.8.2",
 ]
 
 [[package]]
@@ -2760,9 +2824,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "renderdoc-sys"
@@ -2772,9 +2836,9 @@ checksum = "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b"
 
 [[package]]
 name = "rodio"
-version = "0.17.1"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf1d4dea18dff2e9eb6dca123724f8b60ef44ad74a9ad283cdfe025df7e73fa"
+checksum = "3b1bb7b48ee48471f55da122c0044fcc7600cfcc85db88240b89cb832935e611"
 dependencies = [
  "cpal",
  "lewton",
@@ -2786,8 +2850,8 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64 0.21.4",
- "bitflags 2.4.0",
+ "base64 0.21.5",
+ "bitflags 2.4.1",
  "serde",
  "serde_derive",
 ]
@@ -2838,29 +2902,29 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.188"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.107"
+version = "1.0.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
+checksum = "3d1c7e3eac408d115102c4c24ad393e0821bb3a5df4d506a80f85f7a742a526b"
 dependencies = [
  "itoa",
  "ryu",
@@ -2869,18 +2933,18 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96426c9936fd7a0124915f9185ea1d20aa9445cc9821142f0a73bc9207a2e186"
+checksum = "12022b835073e5b11e90a14f86838ceb1c8fb0325b72416845c487ac0fa95e80"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b21f559e07218024e7e9f90f96f601825397de0e25420135f7f952453fed0b"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -2917,9 +2981,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.1"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+checksum = "4dccd0940a2dcdf68d092b8cbab7dc0ad8fa938bf95787e1b916b0e3d0e8e970"
 dependencies = [
  "serde",
 ]
@@ -2968,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2979,12 +3043,12 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.29.10"
+version = "0.29.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a18d114d420ada3a891e6bc8e96a2023402203296a47cdd65083377dad18ba5"
+checksum = "cd727fc423c2060f6c92d9534cef765c65a6ed3f428a03d7def74a8c4348e666"
 dependencies = [
  "cfg-if",
- "core-foundation-sys 0.8.4",
+ "core-foundation-sys",
  "libc",
  "ntapi",
  "once_cell",
@@ -2993,9 +3057,9 @@ dependencies = [
 
 [[package]]
 name = "taffy"
-version = "0.3.14"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ffc872aa6d5b1037b0daf795d7c16defaf2715f1f297475362ad9d30aefb7a"
+checksum = "3c2287b6d7f721ada4cddf61ade5e760b2c6207df041cac9bfaa192897362fd3"
 dependencies = [
  "arrayvec",
  "grid",
@@ -3005,51 +3069,51 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "thiserror"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-core"
-version = "1.0.38"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d97345f6437bb2004cd58819d8a9ef8e36cdd7661c2abc4bbde0a7c40d9f497"
+checksum = "c001ee18b7e5e3f62cbf58c7fe220119e68d902bb7443179c0c8aef30090e999"
 dependencies = [
  "thiserror-core-impl",
 ]
 
 [[package]]
 name = "thiserror-core-impl"
-version = "1.0.38"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10ac1c5050e43014d16b2f94d0d2ce79e65ffdd8b38d8048f9c8f6a8a6da62ac"
+checksum = "e4c60d69f36615a077cc7663b9cb8e42275722d23e58a7fa3d2c7f2915d09d04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.49"
+version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
@@ -3091,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -3104,7 +3168,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.1.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -3113,11 +3177,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3125,20 +3188,20 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -3146,20 +3209,31 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
 dependencies = [
- "lazy_static",
  "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
  "tracing-core",
 ]
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -3170,7 +3244,7 @@ dependencies = [
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log",
+ "tracing-log 0.2.0",
 ]
 
 [[package]]
@@ -3186,9 +3260,9 @@ dependencies = [
 
 [[package]]
 name = "ttf-parser"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49d64318d8311fc2668e48b63969f4343e0a85c4a109aa8460d6672e364b8bd1"
+checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
 
 [[package]]
 name = "twox-hash"
@@ -3220,9 +3294,9 @@ checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
  "serde",
@@ -3270,9 +3344,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -3280,24 +3354,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -3307,9 +3381,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3317,22 +3391,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.38",
+ "syn 2.0.39",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
 
 [[package]]
 name = "wayland-scanner"
@@ -3347,9 +3421,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "50c24a44ec86bb68fbecd1b3efed7e85ea5621b39b35ef2766b66cd984f8010f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3387,7 +3461,7 @@ checksum = "8f478237b4bf0d5b70a39898a66fa67ca3a007d79f2520485b8b0c3dfc46f8c2"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "codespan-reporting",
  "log",
  "naga",
@@ -3412,7 +3486,7 @@ dependencies = [
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "block",
  "core-graphics-types",
  "d3d12",
@@ -3450,7 +3524,7 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c153280bb108c2979eb5c7391cb18c56642dd3c072e55f52065e13e2a1252a"
 dependencies = [
- "bitflags 2.4.0",
+ "bitflags 2.4.1",
  "js-sys",
  "web-sys",
 ]
@@ -3716,7 +3790,7 @@ dependencies = [
  "orbclient",
  "percent-encoding",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "wasm-bindgen",
  "wayland-scanner",
  "web-sys",
@@ -3726,9 +3800,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.5.15"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2e3184b9c4e92ad5167ca73039d0c42476302ab603e2fec4487511f38ccefc"
+checksum = "829846f3e3db426d4cee4510841b71a8e58aa2a76b1132579487ae430ccd9c7b"
 dependencies = [
  "memchr",
 ]
@@ -3755,3 +3829,23 @@ name = "xml-rs"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e97e415490559a91254a2979b4829267a57d2fcd741a98eee8b722fb57289aa0"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7e48ccf166952882ca8bd778a43502c64f33bf94c12ebe2a7f08e5a0f6689f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,6 @@ dependencies = [
 [[package]]
 name = "constructivism_macro_gen"
 version = "0.1.0"
-source = "git+https://github.com/polako-rs/constructivism#d7ec940b32963399b714348df3941d9750e1e411"
 dependencies = [
  "quote",
  "syn 2.0.38",
@@ -1249,7 +1248,6 @@ dependencies = [
 [[package]]
 name = "constructivist"
 version = "0.0.1"
-source = "git+https://github.com/polako-rs/constructivism#d7ec940b32963399b714348df3941d9750e1e411"
 dependencies = [
  "constructivism_macro_gen",
  "proc-macro2",
@@ -2596,11 +2594,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "polako_core"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "polako_constructivism",
+]
+
+[[package]]
 name = "polako_eml"
 version = "0.1.0"
 dependencies = [
  "bevy",
  "polako_constructivism",
+ "polako_core",
  "polako_flow",
  "polako_macro",
 ]
@@ -2611,6 +2618,15 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "polako_constructivism",
+]
+
+[[package]]
+name = "polako_input"
+version = "0.1.0"
+dependencies = [
+ "bevy",
+ "polako_constructivism",
+ "polako_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
 [[package]]
 name = "constructivism_macro_gen"
 version = "0.1.0"
+source = "git+https://github.com/polako-rs/constructivism#0e36fffa34d956bb4841ff574a3294866c9afa21"
 dependencies = [
  "quote",
  "syn 2.0.38",
@@ -1248,6 +1249,7 @@ dependencies = [
 [[package]]
 name = "constructivist"
 version = "0.0.1"
+source = "git+https://github.com/polako-rs/constructivism#0e36fffa34d956bb4841ff574a3294866c9afa21"
 dependencies = [
  "constructivism_macro_gen",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2582,6 +2582,7 @@ dependencies = [
  "polako_constructivism",
  "polako_eml",
  "polako_flow",
+ "polako_input",
  "polako_macro",
 ]
 
@@ -2618,6 +2619,7 @@ version = "0.1.0"
 dependencies = [
  "bevy",
  "polako_constructivism",
+ "polako_input",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,10 @@ repository = "https://github.com/jkb0o/polako"
 [workspace]
 members = [
     "crates/polako_constructivism",
+    "crates/polako_core",
     "crates/polako_eml",
     "crates/polako_flow",
+    "crates/polako_input",
     "crates/polako_macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,5 @@ polako_constructivism = { path = "crates/polako_constructivism" }
 polako_eml = { path = "crates/polako_eml" }
 polako_flow = { path = "crates/polako_flow" }
 polako_macro = { path = "crates/polako_macro" }
+polako_input = { path = "crates/polako_input" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,16 +16,19 @@ members = [
     "crates/polako_flow",
     "crates/polako_input",
     "crates/polako_macro",
+    "crates/polako_ui",
+    "crates/polako_channel",
 ]
 
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.2"
+bevy = "0.12"
 polako_constructivism = { path = "crates/polako_constructivism" }
 polako_eml = { path = "crates/polako_eml" }
 polako_flow = { path = "crates/polako_flow" }
 polako_macro = { path = "crates/polako_macro" }
 polako_input = { path = "crates/polako_input" }
+polako_ui = { path = "crates/polako_ui" }
 

--- a/crates/polako_channel/Cargo.toml
+++ b/crates/polako_channel/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-name = "polako_core"
+name = "polako_channel"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.12"
-polako_constructivism = { path = "../polako_constructivism"}
+bevy = "0.12.1"

--- a/crates/polako_channel/src/lib.rs
+++ b/crates/polako_channel/src/lib.rs
@@ -1,0 +1,51 @@
+use std::{sync::RwLock, thread::ThreadId, rc::Rc, cell::RefCell};
+
+use bevy::{ecs::system::Resource, utils::HashMap};
+
+#[derive(Resource)]
+pub struct Channel<T>(RwLock<HashMap<ThreadId, Rc<RefCell<Vec<T>>>>>);
+unsafe impl<T> Send for Channel<T> {}
+unsafe impl<T> Sync for Channel<T> {}
+impl<T> Channel<T> {
+    pub fn new() -> Self {
+        Self(RwLock::new(HashMap::new()))
+    }
+    pub fn clear(&self) {
+        for cell in self.0.read().unwrap().values() {
+            cell.borrow_mut().clear()
+        }
+    }
+    pub fn send(&self, event: T) {
+        let id = std::thread::current().id();
+        {
+            let read = self.0.read().unwrap();
+            let item = read.get(&id);
+            if let Some(events) = item {
+                events.borrow_mut().push(event);
+                return;
+            }
+        }
+        {
+            self.0
+                .write()
+                .unwrap()
+                .insert(id, Rc::new(RefCell::new(vec![event])));
+        }
+    }
+    pub fn recv<F: FnMut(&T)>(&self, mut recv: F) {
+        for cell in self.0.read().unwrap().values() {
+            let borrow = cell.borrow();
+            for item in borrow.iter() {
+                recv(item)
+            }
+        }
+    }
+
+    pub fn consume<F: FnMut(T)>(&mut self, mut recv: F) {
+        for cell in self.0.write().unwrap().drain() {
+            for item in cell.1.take() {
+                recv(item)
+            }
+        }
+    }
+}

--- a/crates/polako_constructivism/Cargo.toml
+++ b/crates/polako_constructivism/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.2"
+bevy = "0.12"
 polako_macro = { version = "0.1.0", path = "../polako_macro" }

--- a/crates/polako_constructivism/src/bridge.rs
+++ b/crates/polako_constructivism/src/bridge.rs
@@ -68,27 +68,26 @@ derive_construct! {
 }
 
 pub trait ColorProps {
-    fn get_hex(&self) -> String; 
+    fn get_hex(&self) -> String;
     fn set_hex(&mut self, hex: impl AsRef<str>);
 }
 impl ColorProps for Color {
     fn get_hex(&self) -> String {
         format!(
-          "{:02x}{:2x}{:02x}{:02x}",
-          (self.r().clamp(0., 1.) * 255.).round() as usize,
-          (self.g().clamp(0., 1.) * 255.).round() as usize,
-          (self.b().clamp(0., 1.) * 255.).round() as usize,
-          (self.a().clamp(0., 1.) * 255.).round() as usize,
+            "{:02x}{:2x}{:02x}{:02x}",
+            (self.r().clamp(0., 1.) * 255.).round() as usize,
+            (self.g().clamp(0., 1.) * 255.).round() as usize,
+            (self.b().clamp(0., 1.) * 255.).round() as usize,
+            (self.a().clamp(0., 1.) * 255.).round() as usize,
         )
     }
     fn set_hex(&mut self, hex: impl AsRef<str>) {
         let hex = hex.as_ref();
         *self = Color::hex(hex).unwrap_or_else(|_| {
-          info!("Cant parse '{hex}` as color, using WHITE.");
-          Color::WHITE
+            info!("Cant parse '{hex}` as color, using WHITE.");
+            Color::WHITE
         })
-  }
-
+    }
 }
 derive_construct! {
     seq => Color -> Nothing;

--- a/crates/polako_constructivism/src/bridge.rs
+++ b/crates/polako_constructivism/src/bridge.rs
@@ -124,8 +124,8 @@ derive_construct! {
     };
     props => {
         /// How much time has advanced since startup, as f32 seconds.
-        elapsed_seconds: f32 = [elapsed_seconds, readonly];
+        elapsed: f32 = [elapsed_seconds, readonly];
         /// How much time has advanced since the last update, as f32 seconds.
-        delta_seconds: f32 = [delta_seconds, readonly];
+        delta: f32 = [delta_seconds, readonly];
     };
 }

--- a/crates/polako_core/Cargo.toml
+++ b/crates/polako_core/Cargo.toml
@@ -1,13 +1,10 @@
 [package]
-name = "polako_eml"
+name = "polako_core"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.2"
-polako_core = { path = "../polako_core"}
+bevy = "0.11.3"
 polako_constructivism = { path = "../polako_constructivism"}
-polako_flow = { path = "../polako_flow" }
-polako_macro = { path = "../polako_macro" }

--- a/crates/polako_core/src/lib.rs
+++ b/crates/polako_core/src/lib.rs
@@ -4,7 +4,7 @@ use polako_constructivism::{Construct, Lookup, Singleton};
 
 pub trait Signal {
     type Event: Event;
-    type Marker: Singleton;
+    type Descriptor: Singleton;
     type Args: Construct;
     fn filter(event: &Self::Event) -> Option<Entity>;
     // fn emit(world: &mut World, entity: Entity, args: Self::Args);

--- a/crates/polako_core/src/lib.rs
+++ b/crates/polako_core/src/lib.rs
@@ -1,0 +1,36 @@
+use bevy::prelude::{Event, Entity, World, Events};
+use polako_constructivism::{Construct, Lookup, Singleton};
+
+
+pub trait Signal {
+    type Event: Event;
+    type Marker: Singleton;
+    type Args: Construct;
+    fn filter(event: &Self::Event) -> Option<Entity>;
+    // fn emit(world: &mut World, entity: Entity, args: Self::Args);
+    // fn props(&self) -> &'static <Self::Args as Construct>::Props<Lookup> {
+    //     <<Self::Args as Construct>::Props<Lookup> as Singleton>::instance()
+    // }
+    // fn params(&self) -> &'static <Self::Args as Construct>::Params {
+    //     <<Self::Args as Construct>::Params as Singleton>::instance()
+    // }
+}
+
+pub trait Sig {
+    type Marker;
+}
+
+
+pub struct Pressed {
+
+}
+
+pub struct PressedSignalMarker;
+
+impl Sig for Pressed {
+    type Marker = PressedSignalMarker;
+}
+
+pub struct Fields {
+    pressed: <Pressed as Sig>::Marker,
+}

--- a/crates/polako_core/src/lib.rs
+++ b/crates/polako_core/src/lib.rs
@@ -1,5 +1,5 @@
-use bevy::prelude::{Event, Entity, World, Events};
-use polako_constructivism::{Construct, Lookup, Singleton};
+use bevy::prelude::{Event, Entity};
+use polako_constructivism::{Construct, Singleton};
 
 
 pub trait Signal {
@@ -29,8 +29,4 @@ pub struct PressedSignalMarker;
 
 impl Sig for Pressed {
     type Marker = PressedSignalMarker;
-}
-
-pub struct Fields {
-    pressed: <Pressed as Sig>::Marker,
 }

--- a/crates/polako_core/src/lib.rs
+++ b/crates/polako_core/src/lib.rs
@@ -1,6 +1,5 @@
-use bevy::prelude::{Event, Entity};
+use bevy::prelude::{Entity, Event};
 use polako_constructivism::{Construct, Singleton};
-
 
 pub trait Signal {
     type Event: Event;
@@ -20,10 +19,7 @@ pub trait Sig {
     type Marker;
 }
 
-
-pub struct Pressed {
-
-}
+pub struct Pressed {}
 
 pub struct PressedSignalMarker;
 

--- a/crates/polako_eml/Cargo.toml
+++ b/crates/polako_eml/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.2"
+bevy = "0.12"
 polako_core = { path = "../polako_core"}
 polako_constructivism = { path = "../polako_constructivism"}
 polako_flow = { path = "../polako_flow" }

--- a/crates/polako_eml/src/lib.rs
+++ b/crates/polako_eml/src/lib.rs
@@ -2,13 +2,13 @@ use std::{cell::RefCell, marker::PhantomData, rc::Rc};
 
 use bevy::{
     ecs::{
-        system::{Command, CommandQueue, SystemParam},
+        system::{Command, CommandQueue},
         world::EntityMut,
     },
     prelude::{*, Resource},
 };
 use polako_constructivism::{traits::Construct, *};
-use polako_flow::{ChangedEntities, Hand, OnDemandSignal, EnterSignal, UpdateSignal, ComponentChanges, NotifyChange};
+use polako_flow::{OnDemandSignal, EnterSignal, UpdateSignal, NotifyChange};
 
 #[cfg(test)]
 mod tests;

--- a/crates/polako_eml/src/lib.rs
+++ b/crates/polako_eml/src/lib.rs
@@ -3,7 +3,7 @@ use std::{cell::RefCell, marker::PhantomData, rc::Rc};
 use bevy::{
     ecs::{
         system::{Command, CommandQueue},
-        world::EntityMut,
+        world::EntityWorldMut,
     },
     prelude::{Resource, *},
 };
@@ -275,7 +275,7 @@ impl CommandStackItem {
             e.insert(bundle);
         });
     }
-    pub fn entity<F: FnOnce(&mut EntityMut) + Send + Sync + 'static>(
+    pub fn entity<F: FnOnce(&mut EntityWorldMut) + Send + Sync + 'static>(
         &mut self,
         entity: Entity,
         func: F,

--- a/crates/polako_eml/src/lib.rs
+++ b/crates/polako_eml/src/lib.rs
@@ -5,10 +5,10 @@ use bevy::{
         system::{Command, CommandQueue},
         world::EntityMut,
     },
-    prelude::{*, Resource},
+    prelude::{Resource, *},
 };
 use polako_constructivism::{traits::Construct, *};
-use polako_flow::{OnDemandSignal, EnterSignal, UpdateSignal, NotifyChange};
+use polako_flow::{EnterSignal, NotifyChange, OnDemandSignal, UpdateSignal};
 
 #[cfg(test)]
 mod tests;
@@ -21,10 +21,6 @@ pub mod msg {
 pub trait Element: ElementBuilder {
     type Signals: Singleton + 'static;
 }
-
-
-
-
 
 pub trait ElementBuilder: Component + Construct + Sized {
     fn build_element(content: Vec<Entity>) -> Blueprint<Self>;
@@ -74,13 +70,16 @@ pub trait Behavior: Segment + Component {
 /// tree is built. Like `AcceptOnly<T>` in `#[construct(TabView -> AcceptOnly<Tab> -> Div)]
 pub trait Constraint: Segment + IntoBundle {}
 
-
-pub trait PolakoType: TypeReference where Self::Type: Component {
+pub trait PolakoType: TypeReference
+where
+    Self::Type: Component,
+{
     fn notify_changed(&self, commands: &mut Commands, entity: Entity);
 }
 
 impl<T: TypeReference> PolakoType for T
-where Self::Type: Component
+where
+    Self::Type: Component,
 {
     fn notify_changed(&self, commands: &mut Commands, entity: Entity) {
         commands.add(NotifyChange::<Self::Type>::new(entity))
@@ -156,7 +155,6 @@ impl<R: Resource + Construct> Clone for ResourceMark<R> {
     }
 }
 
-
 pub struct Eml<Root: ElementBuilder>(Box<dyn FnOnce(&mut World, Entity)>, PhantomData<Root>);
 
 unsafe impl<Root: ElementBuilder> Send for Eml<Root> {}
@@ -201,10 +199,9 @@ impl ElementBuilder for Empty {
     }
 }
 
-
 pub struct EmptySignals;
 impl Singleton for EmptySignals {
-    fn instance() ->  &'static Self {
+    fn instance() -> &'static Self {
         &EmptySignals
     }
 }

--- a/crates/polako_eml/src/lib.rs
+++ b/crates/polako_eml/src/lib.rs
@@ -5,9 +5,10 @@ use bevy::{
         system::{Command, CommandQueue},
         world::EntityMut,
     },
-    prelude::*,
+    prelude::*, input::{mouse::MouseButtonInput, ButtonState},
 };
 use polako_constructivism::{traits::Construct, *};
+use polako_core::Signal;
 
 #[cfg(test)]
 mod tests;

--- a/crates/polako_eml/src/lib.rs
+++ b/crates/polako_eml/src/lib.rs
@@ -31,7 +31,7 @@ pub trait ElementBuilder: Component + Construct + Sized {
 }
 
 /// Transforms (A, (B, (C, (D, ())))) into (A, ((), (C, ((), ())))
-/// where only A & C impl Bundle (and Component implictly)
+/// where only A & C impl Bundle (and Component implicitly)
 pub trait IntoBundle {
     type Output: Bundle;
     fn into_bundle(self) -> Self::Output;

--- a/crates/polako_eml/src/lib.rs
+++ b/crates/polako_eml/src/lib.rs
@@ -85,7 +85,6 @@ where Self::Type: Component
     fn notify_changed(&self, commands: &mut Commands, entity: Entity) {
         commands.add(NotifyChange::<Self::Type>::new(entity))
     }
-
 }
 
 pub struct Model<E: Element> {

--- a/crates/polako_eml/src/tests.rs
+++ b/crates/polako_eml/src/tests.rs
@@ -1,6 +1,13 @@
+use bevy::ecs::component::TableStorage;
+
 use super::*;
 
-#[derive(Component, Construct)]
+pub struct XXX;
+impl Component for XXX {
+    type Storage = TableStorage;
+}
+
+#[derive(Element)]
 #[construct(Div -> Empty)]
 pub struct Div {}
 
@@ -46,7 +53,7 @@ impl DivDesign {
     }
 }
 
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(Label -> TextElement -> Div)]
 pub struct Label;
 
@@ -58,7 +65,7 @@ impl ElementBuilder for Label {
     }
 }
 
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(Bold -> Label)]
 pub struct Bold {}
 impl ElementBuilder for Bold {
@@ -119,7 +126,7 @@ fn test_bold_text() {
     assert_eq!("bold", &world.query::<&TextElement>().single(world).font);
 }
 
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(UiNode -> Div)]
 pub struct UiNode {}
 impl ElementBuilder for UiNode {
@@ -139,9 +146,9 @@ fn test_blueprint_patch_self() {
 struct TestComponent {
     value: String,
 }
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(MixPatch -> Div)]
-struct MixPatch;
+pub struct MixPatch;
 impl ElementBuilder for MixPatch {
     fn build_element(_: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
@@ -167,9 +174,9 @@ fn test_blueprint_mix_patch() {
         &world.query::<&TestComponent>().single(world).value
     );
 }
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(MixConstruct -> Div)]
-struct MixConstruct;
+pub struct MixConstruct;
 impl ElementBuilder for MixConstruct {
     fn build_element(_: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {

--- a/crates/polako_eml/src/tests.rs
+++ b/crates/polako_eml/src/tests.rs
@@ -19,7 +19,7 @@ impl ElementBuilder for Div {
     }
 }
 
-#[derive(Component, Behaviour)]
+#[derive(Component, Behavior)]
 pub struct TextElement {
     pub text: String,
     #[param(default = format!("regular"))]

--- a/crates/polako_eml/src/tests.rs
+++ b/crates/polako_eml/src/tests.rs
@@ -4,7 +4,7 @@ use super::*;
 #[construct(Div -> Empty)]
 pub struct Div {}
 
-impl Element for Div {
+impl ElementBuilder for Div {
     fn build_element(content: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             Div::Base [[ content ]]
@@ -50,7 +50,7 @@ impl DivDesign {
 #[construct(Label -> TextElement -> Div)]
 pub struct Label;
 
-impl Element for Label {
+impl ElementBuilder for Label {
     fn build_element(_: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             Label::Base
@@ -61,7 +61,7 @@ impl Element for Label {
 #[derive(Component, Construct)]
 #[construct(Bold -> Label)]
 pub struct Bold {}
-impl Element for Bold {
+impl ElementBuilder for Bold {
     fn build_element(_: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             Bold::Base + TextElement(.font: "bold")
@@ -122,7 +122,7 @@ fn test_bold_text() {
 #[derive(Component, Construct)]
 #[construct(UiNode -> Div)]
 pub struct UiNode {}
-impl Element for UiNode {
+impl ElementBuilder for UiNode {
     fn build_element(_: Vec<Entity>) -> Blueprint<Self> {
         blueprint! { UiNode::Base + NodeBundle }
     }
@@ -142,7 +142,7 @@ struct TestComponent {
 #[derive(Component, Construct)]
 #[construct(MixPatch -> Div)]
 struct MixPatch;
-impl Element for MixPatch {
+impl ElementBuilder for MixPatch {
     fn build_element(_: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             MixPatch::Base + TestComponent(.value: "mix_patch")
@@ -170,7 +170,7 @@ fn test_blueprint_mix_patch() {
 #[derive(Component, Construct)]
 #[construct(MixConstruct -> Div)]
 struct MixConstruct;
-impl Element for MixConstruct {
+impl ElementBuilder for MixConstruct {
     fn build_element(_: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             MixConstruct::Base + Name { .value: "mix_construct" }

--- a/crates/polako_eml/src/tests.rs
+++ b/crates/polako_eml/src/tests.rs
@@ -19,7 +19,7 @@ impl ElementBuilder for Div {
     }
 }
 
-#[derive(Component, Behavior)]
+#[derive(Behavior)]
 pub struct TextElement {
     pub text: String,
     #[param(default = format!("regular"))]

--- a/crates/polako_flow/Cargo.toml
+++ b/crates/polako_flow/Cargo.toml
@@ -8,4 +8,5 @@ edition = "2021"
 [dependencies]
 polako_constructivism = { path = "../polako_constructivism"}
 polako_input = { path = "../polako_input"}
-bevy = "0.11.3"
+polako_channel = { path = "../polako_channel"}
+bevy = "0.12"

--- a/crates/polako_flow/Cargo.toml
+++ b/crates/polako_flow/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 polako_constructivism = { path = "../polako_constructivism"}
+polako_input = { path = "../polako_input"}
 bevy = "0.11.3"

--- a/crates/polako_flow/examples/bind.rs
+++ b/crates/polako_flow/examples/bind.rs
@@ -14,7 +14,7 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     let text = commands.spawn(TextBundle::default()).id();
     commands.add(BindResourceToComponent {
-        from: prop!(Time.elapsed_seconds).map(|s| format!("{s}")),
+        from: prop!(Time.elapsed).map(|s| format!("{s}")),
         to: text.set(prop!(Text.text)),
     })
 }

--- a/crates/polako_flow/src/input.rs
+++ b/crates/polako_flow/src/input.rs
@@ -1,0 +1,53 @@
+use polako_constructivism::Singleton;
+use polako_input::{PointerInput, PointerInputData, PointerInputPosition};
+use bevy::prelude::*;
+use bevy::ecs::system::SystemParam;
+use bevy::ecs::world::EntityMut;
+use super::{Signal, Hand, Handler};
+macro_rules! impl_signal {
+    ($variant:ident, $name:ident, $marker:ident) => {
+        pub struct $name;
+        impl Signal for $name {
+            type Event = PointerInput;
+            type Args = PointerInputPosition;
+            type Descriptor = $marker;
+            fn filter(event: &Self::Event) -> Option<Entity> {
+                matches!(event.data, PointerInputData::$variant).then_some(event.entity)
+            }
+        }
+        pub struct $marker;
+        impl Singleton for $marker {
+            fn instance() -> &'static $marker {
+                &$marker
+            }
+        }
+        impl $marker {
+            pub fn emit(&self, world: &mut World, entity: Entity, position: <$name as Signal>::Args) {
+                world
+                    .get_resource_or_insert_with(Events::<PointerInput>::default)
+                    .send(PointerInput {
+                        entity,
+                        position,
+                        data: PointerInputData::$variant,
+                    })
+            }
+
+            pub fn assign<'w, S: SystemParam>(
+                &self,
+                entity: EntityMut<'w>,
+                value: Hand<$name, S>,
+            ) {
+                
+            }
+        }
+    };
+}
+
+impl_signal!(Up, UpSignal, UpSignalMarker);
+impl_signal!(Down, DownSignal, DownSignalMarker);
+impl_signal!(Motion, MotionSignal, MotionSignalMarker);
+impl_signal!(DragStart, DragStSignal, DragStartSignalMarker);
+impl_signal!(Drag, DragSignal, DragSignalMarker);
+impl_signal!(DragStop, DragStopSignal, DragStopSignalMarker);
+impl_signal!(Hover, HoverSignal, HoverSignalMarker);
+impl_signal!(Focus, FocusSignal, FocusSignalMarker);

--- a/crates/polako_flow/src/input.rs
+++ b/crates/polako_flow/src/input.rs
@@ -1,9 +1,8 @@
 use polako_constructivism::Singleton;
 use polako_input::{PointerInput, PointerInputData, PointerInputPosition};
 use bevy::prelude::*;
-use bevy::ecs::system::SystemParam;
-use bevy::ecs::world::EntityMut;
-use super::{Signal, Hand};
+use super::Signal;
+
 macro_rules! impl_signal {
     ($variant:ident, $name:ident, $marker:ident) => {
         pub struct $name;

--- a/crates/polako_flow/src/input.rs
+++ b/crates/polako_flow/src/input.rs
@@ -46,7 +46,7 @@ macro_rules! impl_signal {
                     ) + 'static,
             >(
                 &self,
-                entity: &mut ::bevy::ecs::world::EntityMut<'w>,
+                entity: &mut ::bevy::ecs::world::EntityWorldMut<'w>,
                 func: F,
             ) {
                 let hand = $crate::Hand::new(func);

--- a/crates/polako_flow/src/input.rs
+++ b/crates/polako_flow/src/input.rs
@@ -32,13 +32,13 @@ macro_rules! impl_signal {
                     })
             }
 
-            pub fn assign<'w, S: SystemParam>(
-                &self,
-                _entity: EntityMut<'w>,
-                _value: Hand<$name, S>,
-            ) {
+            // pub fn assign<'w, S: SystemParam>(
+            //     &self,
+            //     _entity: &mut EntityMut<'w>,
+            //     _value: Hand<$name, S>,
+            // ) {
                 
-            }
+            // }
         }
     };
 }

--- a/crates/polako_flow/src/input.rs
+++ b/crates/polako_flow/src/input.rs
@@ -3,7 +3,7 @@ use polako_input::{PointerInput, PointerInputData, PointerInputPosition};
 use bevy::prelude::*;
 use bevy::ecs::system::SystemParam;
 use bevy::ecs::world::EntityMut;
-use super::{Signal, Hand, Handler};
+use super::{Signal, Hand};
 macro_rules! impl_signal {
     ($variant:ident, $name:ident, $marker:ident) => {
         pub struct $name;
@@ -34,8 +34,8 @@ macro_rules! impl_signal {
 
             pub fn assign<'w, S: SystemParam>(
                 &self,
-                entity: EntityMut<'w>,
-                value: Hand<$name, S>,
+                _entity: EntityMut<'w>,
+                _value: Hand<$name, S>,
             ) {
                 
             }

--- a/crates/polako_flow/src/lib.rs
+++ b/crates/polako_flow/src/lib.rs
@@ -844,7 +844,9 @@ fn handle_signals_system<E: Signal, S: SystemParam + 'static>(
     mut params: StaticSystemParam<S>,
 ) {
     // let x = *params;
+    // info!("handling signals systems, num events: {}", reader.len());
     for (entity, event) in reader.iter().filter_map(|e| E::filter(e).map(|n| (n, e))) {
+        info!("handling event on {entity:?}");
         if let Ok(hands) = hands_query.get(entity) {
             hands.iter().for_each(|h| h.func.execute(event, &mut params));    
         }
@@ -880,7 +882,11 @@ impl<T: Event> OnDemandSignal<T> {
 // );
 
 impl OnDemandSignal<EnterSignal> {
-    pub fn assign<'w, S: SystemParam + 'static, F: Fn(&EnterSignal, &mut StaticSystemParam<S>) + 'static>(&self, entity: &mut EntityMut<'w>, func: F) {
+    pub fn assign<'w, S: SystemParam + 'static, F: Fn(&EnterSignal, &mut StaticSystemParam<S>) + 'static>(
+        &self,
+        entity: &mut EntityMut<'w>,
+        func: F
+    ) {
         let hand = Hand::new(func);
         if !entity.contains::<Hands<EnterSignal, S>>() {
             entity.insert((
@@ -888,7 +894,7 @@ impl OnDemandSignal<EnterSignal> {
                 FlowItem,
             ));
         } else {
-            entity.get_mut::<Hands<EnterSignal, S>>().unwrap().0.push(hand);
+            entity.get_mut::<Hands<EnterSignal, S>>().unwrap().push(hand);
         }
         let id = entity.id();
         entity.world_scope(|world| {

--- a/crates/polako_flow/src/lib.rs
+++ b/crates/polako_flow/src/lib.rs
@@ -164,16 +164,12 @@ fn write_component_changes<T: Component, V: Bindable>(
 fn populate_changes<T: Component>(
     changes: Res<Channel<ChangedEntity<T>>>,
     mut changed_entities: ResMut<ChangedEntities<T>>,
-    mut populated: Local<HashSet<Entity>>,
     mut flow: Deferred<FlowLoopControl>,
 ) {
-    populated.clear();
     changed_entities.entities.clear();
     changes.recv(|change| {
         flow.repeat();
-        if populated.insert(change.entity) {
-            changed_entities.entities.push(change.entity)
-        }
+        changed_entities.entities.insert(change.entity);
     })
 }
 
@@ -487,16 +483,20 @@ impl<T> Channel<T> {
 }
 
 #[derive(Resource)]
-struct ChangedEntities<C: Component> {
-    entities: Vec<Entity>,
+pub struct ChangedEntities<C: Component> {
+    entities: HashSet<Entity>,
     marker: PhantomData<C>,
 }
 impl<C: Component> ChangedEntities<C> {
     fn new() -> Self {
         Self {
-            entities: vec![],
+            entities: HashSet::new(),
             marker: PhantomData,
         }
+    }
+
+    pub fn add(&mut self, entity: Entity) {
+        self.entities.insert(entity);
     }
 }
 

--- a/crates/polako_input/Cargo.toml
+++ b/crates/polako_input/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.3"
+bevy = "0.12"
 polako_core = { path = "../polako_core"}
 polako_constructivism = { path = "../polako_constructivism"}

--- a/crates/polako_input/Cargo.toml
+++ b/crates/polako_input/Cargo.toml
@@ -1,13 +1,11 @@
 [package]
-name = "polako_eml"
+name = "polako_input"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.11.2"
+bevy = "0.11.3"
 polako_core = { path = "../polako_core"}
 polako_constructivism = { path = "../polako_constructivism"}
-polako_flow = { path = "../polako_flow" }
-polako_macro = { path = "../polako_macro" }

--- a/crates/polako_input/src/lib.rs
+++ b/crates/polako_input/src/lib.rs
@@ -129,7 +129,7 @@ pub struct PointerQuery {
     global_transform: &'static GlobalTransform,
     filter: Option<&'static ActivePointerFilter>,
     calculated_clip: Option<&'static CalculatedClip>,
-    computed_visibility: Option<&'static ComputedVisibility>,
+    computed_visibility: Option<&'static InheritedVisibility>,
 }
 
 #[derive(Default)]
@@ -218,7 +218,7 @@ pub fn pointer_input_system(
             if let Ok(node) = pointer_query.get(*entity) {
                 // Nodes that are not rendered should not be interactable
                 if let Some(computed_visibility) = node.computed_visibility {
-                    if !computed_visibility.is_visible() {
+                    if !computed_visibility.get() {
                         return None;
                     }
                 }

--- a/crates/polako_input/src/lib.rs
+++ b/crates/polako_input/src/lib.rs
@@ -1,13 +1,12 @@
 use bevy::{
-    ecs::{query::WorldQuery, world::EntityMut},
+    ecs::query::WorldQuery,
     prelude::*,
     render::camera::RenderTarget,
     time::Time,
     ui::{CalculatedClip, Node, UiStack},
     window::{PrimaryWindow, Window, WindowRef},
 };
-use polako_constructivism::{Construct, Singleton};
-use polako_core::*;
+use polako_constructivism::Construct;
 
 #[derive(Construct, Default, Clone)]
 pub struct PointerInputPosition {
@@ -38,9 +37,9 @@ fn t(e: impl Event) {
 }
 #[derive(Event)]
 pub struct PointerInput {
-    entity: Entity,
-    position: PointerInputPosition,
-    data: PointerInputData,
+    pub entity: Entity,
+    pub position: PointerInputPosition,
+    pub data: PointerInputData,
 }
 
 impl PointerInput {
@@ -88,45 +87,7 @@ impl PointerInput {
     }
 }
 
-macro_rules! impl_signal {
-    ($variant:ident, $name:ident, $marker:ident) => {
-        pub struct $name;
-        impl Signal for $name {
-            type Event = PointerInput;
-            type Args = PointerInputPosition;
-            type Marker = $marker;
-            fn filter(event: &Self::Event) -> Option<Entity> {
-                matches!(event.data, PointerInputData::$variant).then_some(event.entity)
-            }
-        }
-        pub struct $marker;
-        impl Singleton for $marker {
-            fn instance() -> &'static $marker {
-                &$marker
-            }
-        }
-        impl $marker {
-            pub fn emit(&self, world: &mut World, entity: Entity, position: <$name as Signal>::Args) {
-                world
-                    .get_resource_or_insert_with(Events::<PointerInput>::default)
-                    .send(PointerInput {
-                        entity,
-                        position,
-                        data: PointerInputData::$variant,
-                    })
-            }
-        }
-    };
-}
 
-impl_signal!(Up, UpSignal, UpSignalMarker);
-impl_signal!(Down, DownSignal, DownSignalMarker);
-impl_signal!(Motion, MotionSignal, MotionSignalMarker);
-impl_signal!(DragStart, DragStSignal, DragStartSignalMarker);
-impl_signal!(Drag, DragSignal, DragSignalMarker);
-impl_signal!(DragStop, DragStopSignal, DragStopSignalMarker);
-impl_signal!(Hover, HoverSignal, HoverSignalMarker);
-impl_signal!(Focus, FocusSignal, FocusSignalMarker);
 
 #[derive(Default)]
 pub enum PointerFilter {

--- a/crates/polako_input/src/lib.rs
+++ b/crates/polako_input/src/lib.rs
@@ -32,9 +32,6 @@ pub enum PointerInputData {
     Focus,
 }
 
-fn t(e: impl Event) {
-    
-}
 #[derive(Event)]
 pub struct PointerInput {
     pub entity: Entity,

--- a/crates/polako_input/src/lib.rs
+++ b/crates/polako_input/src/lib.rs
@@ -94,8 +94,6 @@ impl PointerInput {
     }
 }
 
-
-
 #[derive(Default, Component, Clone, Copy, Debug)]
 pub enum PointerFilter {
     #[default]
@@ -104,7 +102,6 @@ pub enum PointerFilter {
     Pass,
     Block,
 }
-
 
 // derive_behaviour
 
@@ -154,7 +151,7 @@ pub fn bypass_filter_system(
         match filter {
             PointerFilter::Pass => commands.entity(entity).insert(ActivePointerFilter::Pass),
             PointerFilter::Block => commands.entity(entity).insert(ActivePointerFilter::Block),
-            _ => commands.entity(entity).remove::<ActivePointerFilter>()
+            _ => commands.entity(entity).remove::<ActivePointerFilter>(),
         };
     }
 }

--- a/crates/polako_input/src/lib.rs
+++ b/crates/polako_input/src/lib.rs
@@ -1,0 +1,398 @@
+use bevy::{
+    ecs::{query::WorldQuery, world::EntityMut},
+    prelude::*,
+    render::camera::RenderTarget,
+    time::Time,
+    ui::{CalculatedClip, Node, UiStack},
+    window::{PrimaryWindow, Window, WindowRef},
+};
+use polako_constructivism::{Construct, Singleton};
+use polako_core::*;
+
+#[derive(Construct, Default, Clone)]
+pub struct PointerInputPosition {
+    abs: Vec2,
+    rel: Vec2,
+}
+
+#[derive(Construct)]
+pub struct PointerInputDrag {
+    #[prop(construct)]
+    position: PointerInputPosition,
+    source_entities: Vec<Entity>,
+}
+
+pub enum PointerInputData {
+    Up,
+    Down,
+    Motion,
+    DragStart,
+    Drag,
+    DragStop,
+    Hover,
+    Focus,
+}
+
+fn t(e: impl Event) {
+    
+}
+#[derive(Event)]
+pub struct PointerInput {
+    entity: Entity,
+    position: PointerInputPosition,
+    data: PointerInputData,
+}
+
+impl PointerInput {
+    pub fn up(&self) -> bool {
+        match self.data {
+            PointerInputData::Up => true,
+            _ => false,
+        }
+    }
+    pub fn down(&self) -> bool {
+        match self.data {
+            PointerInputData::Down => true,
+            _ => false,
+        }
+    }
+    pub fn motion(&self) -> bool {
+        match self.data {
+            PointerInputData::Motion => true,
+            _ => false,
+        }
+    }
+    pub fn hover(&self) -> bool {
+        match self.data {
+            PointerInputData::Hover => true,
+            _ => false,
+        }
+    }
+    pub fn focus(&self) -> bool {
+        match self.data {
+            PointerInputData::Focus => true,
+            _ => false,
+        }
+    }
+    pub fn drag_start(&self) -> bool {
+        match self.data {
+            PointerInputData::DragStart => true,
+            _ => false,
+        }
+    }
+    pub fn drag(&self) -> bool {
+        matches!(self.data, PointerInputData::Drag)
+    }
+    pub fn drag_stop(&self) -> bool {
+        matches!(self.data, PointerInputData::DragStop)
+    }
+}
+
+macro_rules! impl_signal {
+    ($variant:ident, $name:ident, $marker:ident) => {
+        pub struct $name;
+        impl Signal for $name {
+            type Event = PointerInput;
+            type Args = PointerInputPosition;
+            type Marker = $marker;
+            fn filter(event: &Self::Event) -> Option<Entity> {
+                matches!(event.data, PointerInputData::$variant).then_some(event.entity)
+            }
+        }
+        pub struct $marker;
+        impl Singleton for $marker {
+            fn instance() -> &'static $marker {
+                &$marker
+            }
+        }
+        impl $marker {
+            pub fn emit(&self, world: &mut World, entity: Entity, position: <$name as Signal>::Args) {
+                world
+                    .get_resource_or_insert_with(Events::<PointerInput>::default)
+                    .send(PointerInput {
+                        entity,
+                        position,
+                        data: PointerInputData::$variant,
+                    })
+            }
+        }
+    };
+}
+
+impl_signal!(Up, UpSignal, UpSignalMarker);
+impl_signal!(Down, DownSignal, DownSignalMarker);
+impl_signal!(Motion, MotionSignal, MotionSignalMarker);
+impl_signal!(DragStart, DragStSignal, DragStartSignalMarker);
+impl_signal!(Drag, DragSignal, DragSignalMarker);
+impl_signal!(DragStop, DragStopSignal, DragStopSignalMarker);
+impl_signal!(Hover, HoverSignal, HoverSignalMarker);
+impl_signal!(Focus, FocusSignal, FocusSignalMarker);
+
+#[derive(Default)]
+pub enum PointerFilter {
+    #[default]
+    Default,
+    Ignore,
+    Pass,
+    Block,
+}
+
+#[derive(Component)]
+pub enum ActivePointerFilter {
+    Pass,
+    Block,
+}
+
+#[derive(WorldQuery)]
+#[world_query(mutable)]
+pub struct PointerQuery {
+    entity: Entity,
+    node: &'static Node,
+    global_transform: &'static GlobalTransform,
+    filter: Option<&'static ActivePointerFilter>,
+    calculated_clip: Option<&'static CalculatedClip>,
+    computed_visibility: Option<&'static ComputedVisibility>,
+}
+
+#[derive(Default)]
+pub struct PointerSystemState {
+    pressed_entities: Vec<Entity>,
+    drag_in_seconds: Option<f32>,
+    dragging_from: Vec<Entity>,
+    press_position: Option<Vec2>,
+    last_cursor_position: Option<Vec2>,
+    dragging: bool,
+}
+
+// pointer_input_system is the rewriten bevy's ui_focus_system
+// it emit PointerEvent with associated entities and data.
+pub fn pointer_input_system(
+    mut state: Local<PointerSystemState>,
+    camera: Query<(&Camera, Option<&UiCameraConfig>)>,
+    primary_window: Query<&Window, With<PrimaryWindow>>,
+    windows: Query<&Window, Without<PrimaryWindow>>,
+    mouse_button_input: Res<Input<MouseButton>>,
+    touches_input: Res<Touches>,
+    ui_stack: Res<UiStack>,
+    time: Res<Time>,
+    pointer_query: Query<PointerQuery>,
+    mut events: EventWriter<PointerInput>,
+) {
+    let up =
+        mouse_button_input.just_released(MouseButton::Left) || touches_input.any_just_released();
+    let down =
+        mouse_button_input.just_pressed(MouseButton::Left) || touches_input.any_just_pressed();
+
+    let is_ui_disabled =
+        |camera_ui| matches!(camera_ui, Some(&UiCameraConfig { show_ui: false, .. }));
+
+    let cursor_position = camera
+        .iter()
+        .filter(|(_, camera_ui)| !is_ui_disabled(*camera_ui))
+        .filter_map(|(camera, _)| {
+            if let RenderTarget::Window(window_ref) = camera.target {
+                Some(window_ref)
+            } else {
+                None
+            }
+        })
+        .filter_map(|window_ref| {
+            if let WindowRef::Entity(entity) = window_ref {
+                windows.get(entity).ok()
+            } else {
+                primary_window.get_single().ok()
+            }
+        })
+        .filter(|window| window.focused)
+        .find_map(|window| window.cursor_position())
+        .or_else(|| touches_input.first_pressed_position());
+
+    if down {
+        state.press_position = cursor_position;
+        state.drag_in_seconds = Some(0.5);
+    }
+    let delta = match (cursor_position, state.last_cursor_position) {
+        (Some(c), Some(l)) => c - l,
+        _ => Vec2::ZERO,
+    };
+
+    state.last_cursor_position = cursor_position;
+    let mut moused_over_nodes = ui_stack
+        .uinodes
+        .iter()
+        // reverse the iterator to traverse the tree from closest nodes to furthest
+        .rev()
+        .filter_map(|entity| {
+            if let Ok(node) = pointer_query.get(*entity) {
+                // Nodes that are not rendered should not be interactable
+                if let Some(computed_visibility) = node.computed_visibility {
+                    if !computed_visibility.is_visible() {
+                        return None;
+                    }
+                }
+
+                let position = node.global_transform.translation();
+                let ui_position = position.truncate();
+                let extents = node.node.size() / 2.0;
+                let mut min = ui_position - extents;
+                let mut max = ui_position + extents;
+                if let Some(clip) = node.calculated_clip {
+                    min = Vec2::max(min, clip.clip.min);
+                    max = Vec2::min(max, clip.clip.max);
+                }
+                // if the current cursor position is within the bounds of the node, consider it for
+                // emiting the event
+                let contains_cursor = if let Some(cursor_position) = cursor_position {
+                    (min.x..max.x).contains(&cursor_position.x)
+                        && (min.y..max.y).contains(&cursor_position.y)
+                } else {
+                    false
+                };
+
+                if contains_cursor {
+                    Some(*entity)
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<Entity>>()
+        .into_iter();
+    let mut down_entities = vec![];
+    let mut up_entities = vec![];
+    let mut pressed_entities = vec![];
+    let mut drag_entities = vec![];
+    let mut motion_entities = vec![];
+    let mut drag_start_entities = vec![];
+    let delta_len = delta.length();
+    if let Some(drag_in_seconds) = &mut state.drag_in_seconds {
+        *drag_in_seconds -= time.delta_seconds();
+        *drag_in_seconds -= delta_len / 50.;
+    }
+    if !state.dragging
+        && !state.pressed_entities.is_empty()
+        && state.drag_in_seconds.is_some()
+        && state.drag_in_seconds.unwrap() <= 0.
+    {
+        state.dragging = true;
+        drag_start_entities = state.pressed_entities.clone();
+    }
+    let send_drag_stop = state.dragging && up;
+    let mut drag_stop_entities = vec![];
+    if send_drag_stop {
+        drag_stop_entities = state.dragging_from.clone();
+    }
+
+    let mut iter = pointer_query.iter_many(moused_over_nodes.by_ref());
+    while let Some(node) = iter.fetch_next() {
+        if node.filter.is_none() {
+            continue;
+        }
+        let entity = node.entity;
+
+        if down {
+            state.pressed_entities.push(entity);
+            down_entities.push(entity);
+        }
+        if up {
+            up_entities.push(entity);
+            let pressed_entity_idx = state.pressed_entities.iter().position(|e| *e == entity);
+            if let Some(pressed_entity_idx) = pressed_entity_idx {
+                state.pressed_entities.remove(pressed_entity_idx);
+                pressed_entities.push(entity);
+            }
+        }
+        if delta != Vec2::ZERO {
+            if state.dragging {
+                drag_entities.push(entity);
+            } else {
+                motion_entities.push(entity);
+            };
+        }
+        if send_drag_stop {
+            drag_stop_entities.push(entity);
+        }
+
+        match node.filter.unwrap() {
+            ActivePointerFilter::Block => {
+                break;
+            }
+            ActivePointerFilter::Pass => { /* allow the next node to be processed */ }
+        }
+    }
+
+    let Some(pos) = cursor_position else { return };
+    if down_entities.len() > 0 {
+        // TODO: do not forget about drag_in_seconds here
+        // state.was_down_at = time.elapsed_seconds();
+        for entity in down_entities.iter().copied() {
+            events.send(PointerInput {
+                entity,
+                // TODO: do not forget about calculating screen/windown/viewport/relative position
+                position: PointerInputPosition { abs: pos, rel: pos },
+                data: PointerInputData::Down,
+            });
+        }
+    }
+
+    for entity in motion_entities.iter().copied() {
+        events.send(PointerInput {
+            entity,
+            // TODO: do not forget about calculating screen/windown/viewport/relative position
+            position: PointerInputPosition { abs: pos, rel: pos },
+            // delta,
+            data: PointerInputData::Motion,
+        });
+    }
+    for entity in drag_start_entities.iter().copied() {
+        // state.dragging_from = drag_start_entities.clone();
+        events.send(PointerInput {
+            entity,
+            // TODO: do not forget about calculating screen/windown/viewport/relative position
+            position: PointerInputPosition { abs: pos, rel: pos },
+            // delta,
+            data: PointerInputData::DragStart,
+        });
+    }
+    if drag_stop_entities.is_empty() {
+        for entity in drag_entities.iter().copied() {
+            events.send(PointerInput {
+                entity,
+                // TODO: do not forget about calculating screen/windown/viewport/relative position
+                position: PointerInputPosition { abs: pos, rel: pos },
+                // delta,
+                data: PointerInputData::Drag,
+            });
+        }
+    }
+
+    for entity in drag_stop_entities.iter().copied() {
+        events.send(PointerInput {
+            entity,
+            // TODO: do not forget about calculating screen/windown/viewport/relative position
+            position: PointerInputPosition { abs: pos, rel: pos },
+            // delta,
+            // entities: drag_stop_entities,
+            data: PointerInputData::DragStop,
+        });
+    }
+    for entity in up_entities.iter().copied() {
+        events.send(PointerInput {
+            entity,
+            // TODO: do not forget about calculating screen/windown/viewport/relative position
+            position: PointerInputPosition { abs: pos, rel: pos },
+            // delta,
+            // entities: up_entities,
+            data: PointerInputData::Up,
+        });
+    }
+
+    if up {
+        state.pressed_entities.clear();
+        state.dragging_from.clear();
+        state.press_position = None;
+        state.dragging = false;
+    }
+}

--- a/crates/polako_macro/Cargo.toml
+++ b/crates/polako_macro/Cargo.toml
@@ -8,8 +8,8 @@ proc-macro = true
 
 [dependencies]
 # for local development:
-# constructivist = {  path = "../../../constructivist/crates/constructivist" }
-constructivist = {  git = "https://github.com/polako-rs/constructivism"}
+constructivist = {  path = "../../../constructivist/crates/constructivist" }
+# constructivist = {  git = "https://github.com/polako-rs/constructivism"}
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = "2.0.31"

--- a/crates/polako_macro/Cargo.toml
+++ b/crates/polako_macro/Cargo.toml
@@ -8,8 +8,8 @@ proc-macro = true
 
 [dependencies]
 # for local development:
-constructivist = {  path = "../../../constructivist/crates/constructivist" }
-# constructivist = {  git = "https://github.com/polako-rs/constructivism"}
+# constructivist = {  path = "../../../constructivist/crates/constructivist" }
+constructivist = {  git = "https://github.com/polako-rs/constructivism"}
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = "2.0.31"

--- a/crates/polako_macro/Cargo.toml
+++ b/crates/polako_macro/Cargo.toml
@@ -9,7 +9,7 @@ proc-macro = true
 [dependencies]
 # for local development:
 # constructivist = {  path = "../../../constructivist/crates/constructivist" }
-constructivist = {  git = "https://github.com/polako-rs/constructivism"}
+constructivist = {  version = "0.3.0" }
 proc-macro2 = "1.0.66"
 quote = "1.0.33"
 syn = "2.0.31"

--- a/crates/polako_macro/src/derive.rs
+++ b/crates/polako_macro/src/derive.rs
@@ -1,7 +1,7 @@
-use constructivist::prelude::*;
+use constructivist::{prelude::*, throw, derive::Props};
 use proc_macro2::{Ident, TokenStream};
-use quote::quote;
-use syn::DeriveInput;
+use quote::{quote, format_ident};
+use syn::{DeriveInput, Type, spanned::Spanned, parse_quote, Field, Data};
 
 pub struct DeriveConstraint {
     pub ident: Ident,
@@ -73,4 +73,53 @@ impl DeriveBehaviour {
         let ctx = Context::new("polako");
         input.build(&ctx)
     }
+}
+
+
+pub struct DeriveSignal {
+    ty: Type,
+    args: Option<(DeriveConstruct, Vec<Field>)>,
+}
+
+
+
+impl DeriveSignal {
+    pub fn from_derive(input: DeriveInput) -> syn::Result<Self> {
+        let ident = input.ident.clone();
+        let Data::Struct(data) = &input.data else {
+            throw!(ident, "#[derive(Signal)] available only for structs with named fields.")
+        };
+        let fields = data.fields
+            .iter()
+            .filter(|f| f.ident.is_some() && &f.ident.as_ref().unwrap().to_string() != "entity")
+            .cloned()
+            .collect();
+        let mut input = DeriveConstruct::from_derive(input)?;
+        if !input.props.iter().any(|p| &p.ident.to_string() == "entity") {
+            throw!(input.ty, "Missing required `entity` field");
+        }
+        input.props.retain(|p| &p.ident.to_string() != "entity");
+        input.params.retain(|p| &p.name.to_string() != "entity");
+        let ty = input.ty.clone();
+        let signal_args = format_ident!("{}SignalArgs", ident);
+        input.ty = parse_quote!(quote!{ #signal_args });
+        let args = if input.props.is_empty() {
+            None
+        } else {
+            Some((input, fields))
+        };
+        Ok(DeriveSignal { ty, args })
+    }
+
+    // fn build(&self, ctx: &Context) -> syn::Result<TokenStream> {
+    //     let mut out = quote! { };
+    //     let args_ty = if let Some(args) = &self.args {
+            
+    //         let argsy_ty = args.ty;
+    //         quote! { #args_ty }
+    //     } else {
+    //         quote!{ () }
+    //     }
+
+    // }
 }

--- a/crates/polako_macro/src/derive.rs
+++ b/crates/polako_macro/src/derive.rs
@@ -236,6 +236,9 @@ impl DeriveElement {
                         <#signals_base as #cst::Singleton>::instance()
                     }
                 }
+                impl Signals {
+                    #signals
+                }
             }
 
         })

--- a/crates/polako_macro/src/derive.rs
+++ b/crates/polako_macro/src/derive.rs
@@ -1,7 +1,7 @@
-use constructivist::{prelude::*, throw};
+use constructivist::{prelude::*, throw, exts::*};
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, format_ident};
-use syn::{DeriveInput, spanned::Spanned, Field, Data};
+use syn::{DeriveInput, spanned::Spanned, Field, Data, Attribute, parse::Parse, Token, Type, parse_quote};
 
 use crate::eml::EmlContext;
 
@@ -41,22 +41,34 @@ impl DeriveConstraint {
     }
 }
 
-pub struct DeriveBehaviour {
+pub struct DeriveBehavior {
     ident: Ident,
     segment: DeriveSegment,
+    signals: Vec<AssignedSignal>,
 }
 
-impl DeriveBehaviour {
+impl DeriveBehavior {
     pub fn from_derive(input: DeriveInput) -> syn::Result<Self> {
         Ok(Self {
             ident: input.ident.clone(),
+            signals: AssignedSignal::from_derive(&input)?,
             segment: DeriveSegment::from_derive(input)?,
         })
     }
+    pub fn mod_ident(&self) -> syn::Result<Ident> {
+        Ok(Ident::new(&format!("{}_behavior", self.ident.to_string().to_lowercase()), self.ident.span()))
+    }
     pub fn build(&self, ctx: &EmlContext) -> syn::Result<TokenStream> {
+        let cst = ctx.constructivism();
+        let eml = ctx.path("eml");
         let segment = self.segment.build(ctx)?;
         let ident = &self.ident;
-        let eml = ctx.path("eml");
+        let mod_ident = self.mod_ident()?;
+        let mut signals = quote! {};
+        for signal in self.signals.iter() {
+            let signal = signal.build_getter(ctx)?;
+            signals = quote! { #signals #signal }
+        }
         Ok(quote! {
             #segment
             impl #eml::IntoBundle for #ident {
@@ -65,7 +77,27 @@ impl DeriveBehaviour {
                     self
                 }
             }
-            impl #eml::Behaviour for #ident {
+            impl #eml::Behavior for #ident {
+                type Signals<T: #cst::Singleton + 'static> = #mod_ident::Signals<T>;
+            }
+
+            mod #mod_ident {
+                use super::*;
+                pub struct Signals<T>(::std::marker::PhantomData<T>);
+                impl<T: #cst::Singleton + 'static> ::std::ops::Deref for Signals<T> {
+                    type Target = T;
+                    fn deref(&self) -> &Self::Target {
+                        T::instance()
+                    }
+                }
+                impl<T: #cst::Singleton + 'static> #cst::Singleton for Signals<T> {
+                    fn instance() -> &'static Signals<T> {
+                        &Signals(::std::marker::PhantomData)
+                    }
+                }
+                impl<T: #cst::Singleton + 'static> Signals<T> {
+                    #signals
+                }
 
             }
         })
@@ -77,30 +109,132 @@ impl DeriveBehaviour {
     }
 }
 
+pub struct AssignedSignal {
+    pub docs: Vec<Attribute>,
+    pub ident: Ident,
+    pub ty: Type,
+}
+
+impl AssignedSignal {
+    fn parse_terminated(input: syn::parse::ParseStream) -> syn::Result<Vec<Self>> {
+        Ok(input.parse_terminated(AssignedSignal::parse, Token![,])?.into_iter().collect())
+    }
+
+    pub fn from_derive(input: &DeriveInput) -> syn::Result<Vec<Self>> {
+        Ok(if let Some(attr) = input.attrs
+            .iter()
+            .find(|a| a.path().is_ident("signals"))
+        {
+            attr
+                .parse_args_with(AssignedSignal::parse_terminated)?
+                .into_iter()
+                .collect()
+        } else {
+            vec![]
+        })
+
+    }
+
+    pub fn build_getter(&self, ctx: &EmlContext) -> syn::Result<TokenStream> {
+        let cst = ctx.constructivism();
+        let flow = ctx.path("flow");
+        let ident = &self.ident;
+        let ty = &self.ty;
+        Ok(quote! {
+            pub fn #ident(&self) -> &'static <#ty as #flow::Signal>::Descriptor {
+                <<#ty as #flow::Signal>::Descriptor as #cst::Singleton>::instance()
+            }
+        })
+    }
+}
+
+impl Parse for AssignedSignal {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let docs = Attribute::parse_outer(input)?
+            .into_iter()
+            .filter(|a| a.path().is_ident("doc"))
+            .collect();
+        let ident = input.parse()?;
+        input.parse::<Token![:]>()?;
+        let ty = input.parse()?;
+        Ok(AssignedSignal { docs, ident, ty })
+    }
+}
+
 pub struct DeriveElement {
-    ident: Ident,
-    construct: DeriveConstruct,
+    pub ident: Ident,
+    pub construct: DeriveConstruct,
+    pub signals: Vec<AssignedSignal>,
 }
 
 impl DeriveElement {
+    pub fn mod_ident(&self) -> syn::Result<Ident> {
+        Ok(Ident::new(&format!("{}_element", self.ident.to_string().to_lowercase()), self.ident.span()))
+    }
+
     pub fn from_derive(input: DeriveInput) -> syn::Result<Self> {
+        let signals = AssignedSignal::from_derive(&input)?;
         Ok(Self {
             ident: input.ident.clone(),
-            construct: DeriveConstruct::from_derive(input)?
+            construct: DeriveConstruct::from_derive(input)?,
+            signals,
         })
     }
     pub fn build(&self, ctx: &EmlContext) -> syn::Result<TokenStream> {
+        let cst = ctx.constructivism();
+        let eml = ctx.path("eml");
         let construct = self.construct.build(&ctx.context)?;
         let ident = &self.ident;
-        let eml = ctx.path("eml");
+        let mod_construct = self.construct.mod_ident()?;
+        let mod_element = self.mod_ident()?;
+        let mut signals = quote! {};
+        let design = self.construct.design_ident()?;
+        for signal in self.signals.iter() {
+            let signal = signal.build_getter(ctx)?;
+            signals = quote! { #signals #signal };
+        }
+        let base = &self.construct.sequence.next;
+        let mut signals_base = quote! { <#base as #eml::Element>::Signals };
+        for seg in self.construct.sequence.segments.iter() {
+            signals_base = quote! { <#seg as #eml::Behavior>::Signals<#signals_base> }
+        };
         Ok(quote! {
             #construct
             impl ::bevy::ecs::component::Component for #ident {
                 type Storage = ::bevy::ecs::component::TableStorage;
             }
             impl #eml::Element for #ident {
+                type Signals = #mod_element::Signals;
 
             }
+
+            impl #mod_construct::Props<#cst::Describe> {
+                #signals
+            }
+
+
+            impl #design {
+                pub fn on(&self) -> &'static #mod_element::Signals {
+                    &#mod_element::Signals
+                }
+            }
+
+            mod #mod_element {
+                use super::*;
+                pub struct Signals;
+                impl #cst::Singleton for Signals {
+                    fn instance() -> &'static Signals {
+                        &Signals
+                    }
+                }
+                impl ::std::ops::Deref for Signals {
+                    type Target = #signals_base;
+                    fn deref(&self) -> &Self::Target {
+                        <#signals_base as #cst::Singleton>::instance()
+                    }
+                }
+            }
+
         })
     }
     pub fn build_from_derive(input: DeriveInput) -> syn::Result<TokenStream> {
@@ -131,6 +265,9 @@ impl DeriveSignal {
         if !input.props.iter().any(|p| &p.ident.to_string() == "entity") {
             throw!(input.ty, "Missing required `entity` field");
         }
+        let args = format_ident!("{}Signal", ident);
+        input.ty = parse_quote!(#args);
+        input.sequence.this = input.ty.clone();
         input.props.retain(|p| &p.ident.to_string() != "entity");
         input.params.retain(|p| &p.name.to_string() != "entity");
         let args = if input.props.is_empty() {
@@ -144,37 +281,56 @@ impl DeriveSignal {
     pub fn build(&self, ctx: &EmlContext) -> syn::Result<TokenStream> {
         let cst = ctx.constructivism();
         let flow = ctx.path("flow");
-        let bevy = ctx.path("bevy");
         let ident = &self.ident;
-        let descriptor = format_ident!("{}SignalDescriptor", ident);
-        let (args_ty, args_body) = if let Some((args, fields)) = &self.args {
+        let descriptor = format_ident!("{}Descriptor", ident);
+        let (args_ty, args_body, args_def) = if let Some((args, fields)) = &self.args {
             let args_ty = &args.ty;
             let mut body = quote! { };
+            let mut def = quote! { };
             for field in fields.iter() {
                 let Some(ident) = &field.ident else {
                     throw!(field, "Only named fields supported");
                 };
-                body = quote! { #body #ident = args.#ident, };
+                let ty = &field.ty;
+                body = quote! { #body #ident: args.#ident, };
+                def = quote! { #def #ident: #ty, };
             }
             (
                 quote! { #args_ty },
                 body,
+                def,
             )
         } else {
             (
                 quote!{ () },
                 quote! { },
+                quote! { },
             )
+        };
+        let impl_args = if args_def.is_empty() {
+            quote! { }
+        } else {
+            let args_construct = self.args.as_ref().unwrap().0.build(&ctx.context)?;
+            quote! {
+                pub struct #args_ty {
+                    #args_def
+                }
+                #args_construct
+            }
         };
         Ok(quote! {
             impl #flow::Signal for #ident {
                 type Event = Self;
                 type Args = #args_ty;
                 type Descriptor = #descriptor;
-                fn filter(event: &Self::Event) -> Option<#bevy::prelude::Entity> {
+                fn filter(event: &Self::Event) -> Option<::bevy::prelude::Entity> {
                     Some(event.entity)
                 }
             }
+            impl ::bevy::prelude::Event for #ident {
+
+            }
+            #impl_args
             pub struct #descriptor;
             impl  #cst::Singleton for #descriptor {
                 fn instance() -> &'static Self {
@@ -184,21 +340,21 @@ impl DeriveSignal {
             impl #descriptor {
                 pub fn emit(
                     &self,
-                    world: &mut #bevy::World,
-                    entity: #bevy::prelude::Entity,
-                    args: <$name as #flow::Signal>::Args
+                    world: &mut ::bevy::prelude::World,
+                    entity: ::bevy::prelude::Entity,
+                    args: <#ident as #flow::Signal>::Args
                 ) {
-                    let event = Self {
+                    let event = #ident {
                         entity,
                         #args_body
                     };
-                    world.resource_mut::<#bevy::prelude::Events<Self::Event>>().send(event);
+                    world.resource_mut::<::bevy::prelude::Events<#ident>>().send(event);
                 }
 
-                pub fn assign<'w, S: #bevy::ecs::SystemParam>(
+                pub fn assign<'w, S: ::bevy::ecs::system::SystemParam>(
                     &self,
-                    entity: #bevy::ecs::world::EntityMut<'w>,
-                    value: Hand<#ident, #flow::Handler<S>>,
+                    entity: ::bevy::ecs::world::EntityMut<'w>,
+                    value: #flow::Hand<#ident, S>,
                 ) {
                     
                 }

--- a/crates/polako_macro/src/derive.rs
+++ b/crates/polako_macro/src/derive.rs
@@ -385,7 +385,7 @@ impl DeriveSignal {
                     F: Fn(&#ident, &mut ::bevy::ecs::system::StaticSystemParam<S>) + 'static
                 >(
                     &self,
-                    entity: &mut ::bevy::ecs::world::EntityMut<'w>,
+                    entity: &mut ::bevy::ecs::world::EntityWorldMut<'w>,
                     handler: F,
                 ) {
                     entity.register_signal_handler::<#ident, S, F>(handler);

--- a/crates/polako_macro/src/derive.rs
+++ b/crates/polako_macro/src/derive.rs
@@ -1,4 +1,4 @@
-use constructivist::{prelude::*, throw, exts::*};
+use constructivist::{prelude::*, throw};
 use proc_macro2::{Ident, TokenStream};
 use quote::{quote, format_ident};
 use syn::{DeriveInput, spanned::Spanned, Field, Data, Attribute, parse::Parse, Token, Type, parse_quote};

--- a/crates/polako_macro/src/derive.rs
+++ b/crates/polako_macro/src/derive.rs
@@ -71,6 +71,9 @@ impl DeriveBehavior {
         }
         Ok(quote! {
             #segment
+            impl ::bevy::ecs::component::Component for #ident {
+                type Storage = ::bevy::ecs::component::TableStorage;
+            }
             impl #eml::IntoBundle for #ident {
                 type Output = Self;
                 fn into_bundle(self) -> Self::Output {

--- a/crates/polako_macro/src/derive.rs
+++ b/crates/polako_macro/src/derive.rs
@@ -353,7 +353,7 @@ impl DeriveSignal {
 
                 pub fn assign<'w, S: ::bevy::ecs::system::SystemParam>(
                     &self,
-                    entity: ::bevy::ecs::world::EntityMut<'w>,
+                    entity: &mut ::bevy::ecs::world::EntityMut<'w>,
                     value: #flow::Hand<#ident, S>,
                 ) {
                     

--- a/crates/polako_macro/src/eml.rs
+++ b/crates/polako_macro/src/eml.rs
@@ -801,7 +801,7 @@ impl EmlNode {
         let apply_mixins = self.mixins.build(ctx, &quote! { __model__.entity })?;
         let apply_extensions = self
             .args
-            .build_extensions(ctx, tag, &quote! { __entity__ })?;
+            .build_extensions(ctx, tag, &quote! { &mut __entity__ })?;
         Ok(quote_spanned! {self.tag.span()=> {
             let __model__ = #model;
             let __content__ = #content;
@@ -809,7 +809,7 @@ impl EmlNode {
                 .eml()
                 .write(world, __model__.entity);
             {
-                let __entity__ = world.entity_mut(__model__.entity);
+                let mut __entity__ = world.entity_mut(__model__.entity);
                 #apply_extensions
             }
             #apply_mixins

--- a/crates/polako_macro/src/eml.rs
+++ b/crates/polako_macro/src/eml.rs
@@ -366,6 +366,7 @@ impl EmlDirective {
         let eml = ctx.path("eml");
         Ok(match self {
             EmlDirective::Resource(ident, ty) => quote! {
+                #[allow(unused_variables)]
                 let #ident = #eml::ResourceMark::<#ty>::new();
             },
             _ => quote! { }

--- a/crates/polako_macro/src/eml.rs
+++ b/crates/polako_macro/src/eml.rs
@@ -194,10 +194,10 @@ impl Parse for EmlParams {
         let mut common = vec![];
         let mut extended = vec![];
         while !input.is_empty() {
-            if input.fork().parse::<EmlParam>().is_ok() {
-                extended.push(input.parse()?);
-            } else {
+            if input.fork().parse::<Param<Variant>>().is_ok() {
                 common.push(input.parse()?);
+            } else {
+                extended.push(input.parse()?);
             }
             // if input.fork().parse::<Param<Variant>>().is_ok() {
             //     common.push(input.parse()?);

--- a/crates/polako_macro/src/hand.rs
+++ b/crates/polako_macro/src/hand.rs
@@ -141,10 +141,10 @@ impl<'a> HandContext<'a> {
                         MarkKind::Resource => {
                             header = quote! { 
                                 #header
-                                let var = {
+                                let #var = {
                                     let _host = _params.#param_idx();
                                     #get.into_value().get()
-                                }
+                                };
                             }
                         }
                     }
@@ -165,11 +165,11 @@ impl<'a> HandContext<'a> {
                         MarkKind::Resource => {
                             header = quote! { 
                                 #header
-                                let var = {
+                                let #var = {
                                     let _inset = _params.#param_idx();
                                     let _host = &_inset;
                                     #get.into_value().get()
-                                }
+                                };
                             }
                         }
                     }

--- a/crates/polako_macro/src/hand.rs
+++ b/crates/polako_macro/src/hand.rs
@@ -112,8 +112,8 @@ impl Hand {
 
 
         Ok(quote!{
-            #flow::Hand::new(move |_params: &mut (#sp_decl)| {
-                let (#sp_decs) = _params;
+            #flow::Hand::new(move |_params: &mut ::bevy::ecs::system::StaticSystemParam<(#sp_decl)>| {
+                let (#sp_decs) = ::std::ops::DerefMut::deref_mut(_params);
                 #body
             })
         })

--- a/crates/polako_macro/src/hand.rs
+++ b/crates/polako_macro/src/hand.rs
@@ -39,9 +39,9 @@ impl PartialEq for AccessPoint {
     fn eq(&self, other: &Self) -> bool {
         match (&self.mark.kind, &other.mark.kind) {
             (MarkKind::Entity, MarkKind::Entity) => {
-                self.mark.ident == other.mark.ident && self.prop == other.prop
+                self.mark.ty == other.mark.ty && self.prop == other.prop
             },
-            (MarkKind::Resource, MarkKind::Resource) => self.mark.ident == other.mark.ident,
+            (MarkKind::Resource, MarkKind::Resource) => self.mark.ty == other.mark.ty,
             _ => false
         }
     }

--- a/crates/polako_macro/src/hand.rs
+++ b/crates/polako_macro/src/hand.rs
@@ -1,0 +1,445 @@
+use std::fmt::Debug;
+
+use constructivist::throw;
+use proc_macro2::Ident;
+use quote::{ToTokens, format_ident, quote};
+use syn::{Lit, parse::Parse, Token, token, LitStr, parenthesized, parse2};
+
+/// Samples:
+/// ```ignore
+/// resource(time, Time);
+/// entity(label, Label);
+/// label.on.update() -> {
+///     label.text = time.elapsed_seconds.fmt("{:0.2}");
+/// }
+/// ```
+/// 
+/// ```ignore
+/// Resolves into ast:
+/// Statement::AssignToComponent(
+///     Path(label.text),
+///     Expr::Format(
+///         Expr::ReadResource(time.elapsed_seconds),
+///         "{:0.2}"
+///     )
+/// )
+/// ```
+#[derive(Clone)]
+pub struct Path(Vec<Ident>);
+
+impl<S: AsRef<str>> From<Vec<S>> for Path {
+    fn from(value: Vec<S>) -> Self {
+        Path(value.into_iter().map(|s| format_ident!("{}", s.as_ref())).collect())
+    }
+}
+
+impl ToString for Path {
+    fn to_string(&self) -> String {
+        self.0.iter().map(|i| i.to_string()).collect::<Vec<_>>().join(".")
+    }
+}
+
+impl PartialEq for Path {
+    fn eq(&self, other: &Self) -> bool {
+        let a = self.0.iter().map(|i| i.to_string()).collect::<Vec<_>>();
+        let b = other.0.iter().map(|i| i.to_string()).collect::<Vec<_>>();
+        a == b
+    }
+}
+
+impl Parse for Path {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut parts = vec![];
+        loop {
+            // ite is tail method
+            if input.peek(Token![.]) && input.peek2(syn::Ident) && input.peek3(token::Paren) {
+                if parts.is_empty() {
+                    throw!(input, "Expected Path");
+                } else {
+                    return Ok(Path(parts))
+                }
+            }
+            if input.peek(Token![.]) {
+                input.parse::<Token![.]>()?;
+            }
+            parts.push(input.parse()?);
+            if !input.peek(Token![.]) {
+                break;
+            }
+        }
+        Ok(Path(parts))
+    }
+}
+
+pub struct Format(LitStr);
+
+impl<S: AsRef<str>> From<S> for Format {
+    fn from(value: S) -> Self {
+        let value = format!("\"{}\"", value.as_ref());
+        Format(parse2(value.parse().unwrap()).unwrap())
+    }
+}
+
+impl Parse for Format {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        input.parse::<Token![.]>()?;
+        let ident = input.parse::<Ident>()?;
+        if &ident.to_string() != "fmt" {
+            throw![ident, "Expected .fmt(...)"]
+        }
+        let content;
+        parenthesized!(content in input);
+        Ok(Format(content.parse()?))
+    }
+}
+
+pub enum Statement {
+    Assign(Path, Expr),
+}
+
+pub enum Expr {
+    Const(Lit),
+    Format(Box<Expr>, Format),
+    Read(Path),
+    Add(Box<Expr>, Box<Expr>),
+    Sub(Box<Expr>, Box<Expr>),
+    Mul(Box<Expr>, Box<Expr>),
+    Div(Box<Expr>, Box<Expr>),
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum Op {
+    Add,
+    Sub,
+    Mul,
+    Div,
+    Max,
+}
+
+impl Op {
+    pub fn priority(&self) -> u8 {
+        match self {
+            Self::Mul |
+            Self::Div => 0,
+            Self::Add |
+            Self::Sub => 1,
+            Self::Max => 2
+        }
+    }
+
+    pub fn priorities() -> std::ops::Range<u8> {
+        0..Op::Max.priority()
+    }
+
+    pub fn into_expr(self, left: Expr, right: Expr) -> Expr {
+        match self {
+            Op::Add => Expr::Add(left.into(), right.into()),
+            Op::Sub => Expr::Sub(left.into(), right.into()),
+            Op::Mul => Expr::Mul(left.into(), right.into()),
+            Op::Div => Expr::Div(left.into(), right.into()),
+            Op::Max => panic!("Non-binary expression: {self:?}")
+        }
+    }
+}
+
+impl Expr {
+
+    pub fn flattern(self) -> Vec<(Op, Expr)> {
+        let mut root = Some(self);
+        let mut flat = vec![];
+        let mut op = Op::Max;
+        while let Some(node) = root {
+            (root, op) = match node {
+                Expr::Add(left, right) => {
+                    flat.push((op, *left));
+                    (Some(*right), Op::Add)
+                },
+                Expr::Sub(left, right) => {
+                    flat.push((op, *left));
+                    (Some(*right), Op::Sub)
+                },
+                Expr::Mul(left, right) => {
+                    flat.push((op, *left));
+                    (Some(*right), Op::Mul)
+                },
+                Expr::Div(left, right) => {
+                    flat.push((op, *left));
+                    (Some(*right), Op::Div)
+                },
+                expr => {
+                    flat.push((op, expr));
+                    (None, Op::Max)
+                }
+            }
+        }
+        flat
+    }
+
+    pub fn reduce(self) -> Self {
+        let mut flat = self.flattern();
+        for priority in Op::priorities() {
+            let mut idx = 0;
+            while flat.len() > idx + 1 {
+                if flat[idx + 1].0.priority() > priority {
+                    idx += 1;
+                    continue;
+                }
+                let (prev, left) = flat.remove(idx);
+                let (op, right) = flat.remove(idx);
+                flat.insert(idx, (prev, op.into_expr(left, right)));
+            }
+        }
+        flat.pop().unwrap().1
+    }
+}
+
+impl From<f32> for Expr {
+    fn from(value: f32) -> Self {
+        let value = format!("{value}");
+        Expr::Const(parse2(value.parse().unwrap()).unwrap())
+    }
+}
+impl From<f32> for Box<Expr> {
+    fn from(value: f32) -> Self {
+        let value = format!("{value}");
+        Box::new(Expr::Const(parse2(value.parse().unwrap()).unwrap()))
+    }
+}
+impl From<i32> for Expr {
+    fn from(value: i32) -> Self {
+        let value = format!("{value}");
+        Expr::Const(parse2(value.parse().unwrap()).unwrap())
+    }
+}
+impl From<i32> for Box<Expr> {
+    fn from(value: i32) -> Self {
+        let value = format!("{value}");
+        Box::new(Expr::Const(parse2(value.parse().unwrap()).unwrap()))
+    }
+}
+impl From<&'static str> for Expr {
+    fn from(value: &'static str) -> Self {
+        let value = format!("\"{value}\"");
+        Expr::Const(parse2(quote! { #value }).unwrap())
+    }
+}
+impl From<&'static str> for Box<Expr> {
+    fn from(value: &'static str) -> Self {
+        let value = format!("\"{value}\"");
+        Box::new(Expr::Const(parse2(quote! { #value }).unwrap()))
+    }
+}
+
+impl Parse for Expr {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut step = None;
+        let span = input.fork();
+        loop {
+            if input.is_empty() || input.peek(Token![;]) {
+                break;
+            }
+            let Some(expr) = step else {
+                if input.peek(Lit) {
+                    step = Some(Expr::Const(input.parse()?));
+                } else if input.fork().parse::<Path>().is_ok() {
+                    step = Some(Expr::Read(input.parse()?));
+                } else {
+                    throw!(input, "Not an hand expression");
+                }
+                continue;
+            };
+            if input.fork().parse::<Format>().is_ok() {
+                step = Some(Expr::Format(Box::new(expr), input.parse()?));
+                continue;
+            }
+            if input.peek(Token![*]) {
+                input.parse::<Token![*]>()?;
+                step = Some(Expr::Mul(Box::new(expr), Box::new(input.parse()?)));
+                continue;
+            }
+            if input.peek(Token![/]) {
+                input.parse::<Token![/]>()?;
+                step = Some(Expr::Div(Box::new(expr), Box::new(input.parse()?)));
+                continue;
+            }
+            if input.peek(Token![+]) {
+                input.parse::<Token![+]>()?;
+                step = Some(Expr::Add(Box::new(expr), Box::new(input.parse()?)));
+                continue;
+            }
+            if input.peek(Token![-]) {
+                input.parse::<Token![-]>()?;
+                step = Some(Expr::Sub(Box::new(expr), Box::new(input.parse()?)));
+                continue;
+            }
+            throw!(input, "Unexpected expression");
+        }
+        if let Some(expr) = step {
+            Ok(expr)
+        } else {
+            throw!(input, "Expected expression.");
+        }
+    }
+}
+
+impl Debug for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let formatted = match self {
+            Expr::Const(v) => format!("{}", v.clone().into_token_stream().to_string()),
+            Expr::Read(path) => format!("read({})", path.to_string()),
+            Expr::Format(expr, fmt) => format!("fmt({:?}, \"{}\")", expr, fmt.0.value()),
+            Expr::Add(left, right) => format!("add({:?}, {:?})", left, right),
+            Expr::Sub(left, right) => format!("sub({:?}, {:?})", left, right),
+            Expr::Mul(left, right) => format!("mul({:?}, {:?})", left, right),
+            Expr::Div(left, right) => format!("div({:?}, {:?})", left, right),
+        };
+        f.write_str(&formatted)?;
+        Ok(())
+    }
+}
+
+
+impl PartialEq for Expr {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Expr::Const(ca), Expr::Const(cb)) => {
+                let ca = ca.clone().into_token_stream().to_string();
+                let cb = cb.clone().into_token_stream().to_string();
+                ca == cb
+            },
+            (Expr::Format(expr_a, fmt_a), Expr::Format(expr_b, fmt_b)) => {
+                expr_a == expr_b && fmt_a.0.value() == fmt_b.0.value()
+            },
+            (Expr::Read(path_a), Expr::Read(path_b)) => {
+                path_a == path_b
+            },
+            (Expr::Add(left_a, right_a), Expr::Add(left_b, right_b)) => {
+                left_a == left_b && right_a == right_b
+            },
+            (Expr::Mul(left_a, right_a), Expr::Mul(left_b, right_b)) => {
+                left_a == left_b && right_a == right_b
+            },
+            (Expr::Sub(left_a, right_a), Expr::Sub(left_b, right_b)) => {
+                left_a == left_b && right_a == right_b
+            },
+            (Expr::Div(left_a, right_a), Expr::Div(left_b, right_b)) => {
+                left_a == left_b && right_a == right_b
+            },
+            _ => false
+        }
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use syn::parse2;
+
+    use super::*;
+    fn expr(from: &'static str) -> Expr {
+        let expr = parse2::<Expr>(from.parse().unwrap()).unwrap();
+        expr.reduce()
+    }
+
+    
+    fn add<A: Into<Box<Expr>>, B: Into<Box<Expr>>>(a: A, b: B) -> Expr {
+        Expr::Add(a.into(), b.into())
+    }
+    fn sub<A: Into<Box<Expr>>, B: Into<Box<Expr>>>(a: A, b: B) -> Expr {
+        Expr::Sub(a.into(), b.into())
+    }
+    fn mul<A: Into<Box<Expr>>, B: Into<Box<Expr>>>(a: A, b: B) -> Expr {
+        Expr::Mul(a.into(), b.into())
+    }
+    fn div<A: Into<Box<Expr>>, B: Into<Box<Expr>>>(a: A, b: B) -> Expr {
+        Expr::Div(a.into(), b.into())
+    }
+    fn read<S: AsRef<str>>(value: S) -> Expr {
+        Expr::Read(Path(value.as_ref().split(".").map(|s| format_ident!("{s}")).collect()))
+    }
+    #[test]
+    fn test_expr_basics() {
+        assert_eq!(expr("a.b"), read("a.b"));
+        assert_eq!(
+            expr("a.b.fmt(\"{}\")"),
+            Expr::Format(read("a.b").into(), "{}".into()),
+        );
+        assert_eq!(expr("42"), 42.into());
+        assert_eq!(expr("1 + 2"), add(1, 2));
+        assert_eq!(expr("1 - 2"), sub(1, 2));
+        assert_eq!(expr("1 * 2"), mul(1, 2));
+        assert_eq!(expr("1 / 2"), div(1, 2));
+
+    }
+    #[test]
+    fn test_expr_basic_op_priority() {
+        let e = expr("1 + 2 * 3");
+        assert_eq!(e, add(1, mul(2, 3)));
+        let e = expr("1 * 2 + 3");
+        assert_eq!(e, add(mul(1, 2), 3));
+        let e = expr("1 * 2 + 3 * 4");
+        assert_eq!(e, add(
+            mul(1, 2),
+            mul(3, 4),
+        ));
+        let e = expr("1 + 2 * 3 + 4");
+        assert_eq!(e, add(
+            add(1, mul(2, 3)), 4
+        ));
+        let e = expr("1 - 2 + 3");
+        assert_eq!(e, add(sub(1, 2), 3));
+        let e = expr("1 - 2 * 3 + 4");
+        assert_eq!(e, add(
+            sub(1, mul(2, 3)), 4
+        ));
+        let e = expr("1 - 2 * 3 - 4");
+        assert_eq!(e, sub(
+            sub(1, mul(2, 3)), 4
+        ));
+        let e = expr("1 * 2 - 3 * 4");
+        assert_eq!(e, sub(mul(1, 2), mul(3,4)));
+        let e = expr("1 * 2 - 3 * 4 + 5 * 6");
+        assert_eq!(e, add(
+            sub(mul(1, 2), mul(3,4)),
+            mul(5, 6)
+        ));
+        // [1, 2, 3].iter().fo
+        let e = expr("1 / 2 * 3");
+        assert_eq!(e, mul(div(1, 2), 3));
+        let e = expr("1 / 2 / 3");
+        assert_eq!(e, div(div(1, 2), 3));
+        let e = expr("1 * 2 * 3 + 4 * 5 * 6");
+        assert_eq!(e, add(
+            mul(mul(1, 2), 3),
+            mul(mul(4, 5), 6),
+        ));
+        let e = expr("1 / 2 * 3 + 4 / 5 * 6");
+        assert_eq!(e, add(
+            mul(div(1, 2), 3),
+            mul(div(4, 5), 6),
+        ));
+        let e = expr("1 / 2 / 3 + 4 / 5 / 6");
+        assert_eq!(e, add(
+            div(div(1, 2), 3),
+            div(div(4, 5), 6),
+        ));
+        let e = expr("1 - 2 / 3 / 4 - 5 / 6");
+        assert_eq!(e, sub(
+            sub(1, div(div(2, 3), 4)),
+            div(5, 6)
+        ));
+    }
+    #[test]
+    fn test_expr_prop_op_priority() {
+        let e = expr("a.b + c.d * e.f");
+        assert_eq!(e, add(read("a.b"), mul(read("c.d"), read("e.f"))));
+        let e = expr("a.b * c.d + e.f");
+        assert_eq!(e, add(mul(read("a.b"), read("c.d")), read("e.f")));
+        let e = expr("a.b * 1 + b.c * 2");
+        assert_eq!(e, add(mul(read("a.b"), 1), mul(read("b.c"), 2)));
+        let e = expr("1 / 2 - a.b * 3 + 4");
+        assert_eq!(e, add(
+            sub(div(1, 2), mul(read("a.b"), 3)), 4
+        ));
+    }
+}

--- a/crates/polako_macro/src/lib.rs
+++ b/crates/polako_macro/src/lib.rs
@@ -10,6 +10,7 @@ mod derive;
 mod eml;
 mod variant;
 mod exts;
+mod hand;
 
 #[proc_macro]
 pub fn eml(input: TokenStream) -> TokenStream {

--- a/crates/polako_macro/src/lib.rs
+++ b/crates/polako_macro/src/lib.rs
@@ -1,5 +1,5 @@
 use constructivist::prelude::*;
-use derive::{DeriveBehaviour, DeriveConstraint, DeriveElement, DeriveSignal};
+use derive::{DeriveBehavior, DeriveConstraint, DeriveElement, DeriveSignal};
 use eml::Eml;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
@@ -41,10 +41,10 @@ pub fn constraint_derive(input: TokenStream) -> TokenStream {
     })
 }
 
-#[proc_macro_derive(Behaviour, attributes(param, prop))]
+#[proc_macro_derive(Behavior, attributes(param, prop))]
 pub fn behaviour_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
-    TokenStream::from(match DeriveBehaviour::build_from_derive(input) {
+    TokenStream::from(match DeriveBehavior::build_from_derive(input) {
         Ok(stream) => stream,
         Err(e) => e.to_compile_error(),
     })

--- a/crates/polako_macro/src/lib.rs
+++ b/crates/polako_macro/src/lib.rs
@@ -1,5 +1,5 @@
 use constructivist::prelude::*;
-use derive::{DeriveBehaviour, DeriveConstraint};
+use derive::{DeriveBehaviour, DeriveConstraint, DeriveElement, DeriveSignal};
 use eml::Eml;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
@@ -45,6 +45,24 @@ pub fn constraint_derive(input: TokenStream) -> TokenStream {
 pub fn behaviour_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(match DeriveBehaviour::build_from_derive(input) {
+        Ok(stream) => stream,
+        Err(e) => e.to_compile_error(),
+    })
+}
+
+#[proc_macro_derive(Element, attributes(construct, param, prop))]
+pub fn element_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(match DeriveElement::build_from_derive(input) {
+        Ok(stream) => stream,
+        Err(e) => e.to_compile_error(),
+    })
+}
+
+#[proc_macro_derive(Signal, attributes(construct, param, prop))]
+pub fn signal_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    TokenStream::from(match DeriveSignal::build_from_derive(input) {
         Ok(stream) => stream,
         Err(e) => e.to_compile_error(),
     })

--- a/crates/polako_macro/src/lib.rs
+++ b/crates/polako_macro/src/lib.rs
@@ -4,7 +4,7 @@ use eml::Eml;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-implement_constructivism_macro!("polako", variant::Variant);
+implement_constructivism_macro!("polako", variant::Variant, eml::EmlContext);
 
 mod derive;
 mod eml;

--- a/crates/polako_macro/src/lib.rs
+++ b/crates/polako_macro/src/lib.rs
@@ -8,9 +8,9 @@ implement_constructivism_macro!("polako", variant::Variant, eml::EmlContext);
 
 mod derive;
 mod eml;
-mod variant;
 mod exts;
 mod hand;
+mod variant;
 
 #[proc_macro]
 pub fn eml(input: TokenStream) -> TokenStream {

--- a/crates/polako_macro/src/lib.rs
+++ b/crates/polako_macro/src/lib.rs
@@ -50,7 +50,7 @@ pub fn behaviour_derive(input: TokenStream) -> TokenStream {
     })
 }
 
-#[proc_macro_derive(Element, attributes(construct, param, prop))]
+#[proc_macro_derive(Element, attributes(construct, param, prop, signals))]
 pub fn element_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     TokenStream::from(match DeriveElement::build_from_derive(input) {

--- a/crates/polako_macro/src/variant.rs
+++ b/crates/polako_macro/src/variant.rs
@@ -1,4 +1,7 @@
-use constructivist::{proc::{Value, ContextLike, Ref}, throw};
+use constructivist::{
+    proc::{ContextLike, Ref, Value},
+    throw,
+};
 use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::quote;
 use syn::{
@@ -9,7 +12,7 @@ use syn::{
     Expr, Ident, Token,
 };
 
-use crate::{hand::Hand, eml::EmlContext};
+use crate::{eml::EmlContext, hand::Hand};
 
 #[derive(Clone)]
 pub enum Variant {

--- a/crates/polako_macro/src/variant.rs
+++ b/crates/polako_macro/src/variant.rs
@@ -1,4 +1,4 @@
-use constructivist::{proc::{Value, ContextLike}, throw};
+use constructivist::{proc::{Value, ContextLike, Ref}, throw};
 use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::quote;
 use syn::{
@@ -52,10 +52,10 @@ impl ContextLike for EmlContext {
 }
 impl Value for Variant {
     type Context = EmlContext;
-    fn build(item: &Self, ctx: &EmlContext) -> syn::Result<TokenStream> {
+    fn build(item: &Self, ctx: Ref<EmlContext>) -> syn::Result<TokenStream> {
         Ok(match item {
             Variant::Expr(e) => quote! { #e },
-            Variant::Color(c) => c.build(ctx)?,
+            Variant::Color(c) => c.build(ctx.clone())?,
             Variant::Hand(h) => h.build(ctx)?,
             Variant::Prop(_) => quote! {},
         })
@@ -133,7 +133,7 @@ impl Color {
             }
         }
     }
-    pub fn build(&self, ctx: &EmlContext) -> syn::Result<TokenStream> {
+    pub fn build(&self, ctx: Ref<EmlContext>) -> syn::Result<TokenStream> {
         let (r, g, b, a) = self.rgba()?;
         let bevy = ctx.path("bevy");
         Ok(quote!(#bevy::prelude::Color::rgba(#r, #g, #b, #a)))

--- a/crates/polako_macro/src/variant.rs
+++ b/crates/polako_macro/src/variant.rs
@@ -1,4 +1,4 @@
-use constructivist::{prelude::Context, proc::{Value, ContextLike}, throw};
+use constructivist::{proc::{Value, ContextLike}, throw};
 use proc_macro2::{Span, TokenStream, TokenTree};
 use quote::quote;
 use syn::{
@@ -9,7 +9,7 @@ use syn::{
     Expr, Ident, Token,
 };
 
-use crate::{hand::{Statement, Hand}, eml::EmlContext};
+use crate::{hand::Hand, eml::EmlContext};
 
 #[derive(Clone)]
 pub enum Variant {
@@ -109,7 +109,7 @@ impl Color {
                 ((self.value & 0x000f) >> 00) as f32 / 15.,
             )),
 
-            // rrggbb, alpha = 1.0
+            // RR/GG/BB, alpha = 1.0
             6 => Ok((
                 ((self.value & 0x00ff0000) >> 16) as f32 / 255.,
                 ((self.value & 0x0000ff00) >> 08) as f32 / 255.,

--- a/crates/polako_ui/Cargo.toml
+++ b/crates/polako_ui/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "polako_ui"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+bevy = "0.12"
+bevy-vello = { git = "https://github.com/vectorgameexperts/bevy-vello.git", rev = "v0.3" }
+peniko = { git = "https://github.com/linebender/peniko", rev = "629fc3325b016a8c98b1cd6204cb4ddf1c6b3daa" }
+taffy = "0.3.18"
+vello = { git = "https://github.com/linebender/vello", rev = "28914d66f675efecf03c53261a0fb1b8ecce4fe9" }
+polako_channel = { path = "../polako_channel" }

--- a/crates/polako_ui/examples/vector.rs
+++ b/crates/polako_ui/examples/vector.rs
@@ -1,0 +1,246 @@
+use bevy::render::{Render, RenderSet};
+use bevy::utils::HashSet;
+use bevy::utils::synccell::SyncCell;
+use vello::kurbo::{Affine, Rect, Stroke};
+use vello::peniko::{Color, Fill};
+use vello::{Renderer, RendererOptions, Scene, SceneBuilder, SceneFragment};
+
+
+
+use bevy::{
+    prelude::*,
+    render::{
+        extract_component::{ExtractComponent, ExtractComponentPlugin},
+        render_asset::RenderAssets,
+        render_resource::{
+            Extent3d, TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
+        },
+        renderer::{RenderDevice, RenderQueue},
+        RenderApp,
+    },
+};
+
+#[derive(Component)]
+pub struct Tst(usize);
+
+fn t(mut q: Query<Option<&mut Tst>>) {
+    for i in q.iter_mut() {
+
+    }
+}
+
+#[derive(Resource)]
+struct VelloRenderer(SyncCell<Renderer>);
+
+impl FromWorld for VelloRenderer {
+    fn from_world(world: &mut World) -> Self {
+        let device = world.resource::<RenderDevice>();
+        let queue = world.resource::<RenderQueue>();
+
+        VelloRenderer(SyncCell::new(
+            Renderer::new(
+                device.wgpu_device(),
+                RendererOptions {
+                    surface_format: None,
+                    timestamp_period: queue.0.get_timestamp_period(),
+                    antialiasing_support: vello::AaSupport::all(),
+                    use_cpu: false,
+                },
+            )
+            .unwrap(),
+        ))
+    }
+}
+
+struct VelloPlugin;
+
+impl Plugin for VelloPlugin {
+    fn build(&self, app: &mut App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+        // This should probably use the render graph, but working out the dependencies there is awkward
+        render_app.add_systems(Render, render_scenes.in_set(RenderSet::Render));
+    }
+
+    fn finish(&self, app: &mut App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+        render_app.init_resource::<VelloRenderer>();
+    }
+}
+
+fn render_scenes(
+    mut renderer: ResMut<VelloRenderer>,
+    mut scenes: Query<&VelloScene>,
+    gpu_images: Res<RenderAssets<Image>>,
+    device: Res<RenderDevice>,
+    queue: Res<RenderQueue>,
+) {
+    for scene in &mut scenes {
+        let gpu_image = gpu_images.get(&scene.1).unwrap();
+        let params = vello::RenderParams {
+            base_color: vello::peniko::Color::TRANSPARENT,
+            width: gpu_image.size.x as u32,
+            height: gpu_image.size.y as u32,
+            antialiasing_method: vello::AaConfig::Msaa8,
+        };
+        renderer
+            .0
+            .get()
+            .render_to_texture(
+                device.wgpu_device(),
+                &queue,
+                &scene.0,
+                &gpu_image.texture_view,
+                &params,
+            )
+            .unwrap();
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(VelloPlugin)
+        .add_systems(Startup, setup)
+        .add_plugins(ExtractComponentPlugin::<VelloScene>::default())
+        .add_systems(Update, render_fragment)
+        .run()
+
+
+}
+
+#[derive(Component)]
+pub struct VelloTarget(Handle<Image>);
+
+#[derive(Component)]
+// In the future, this will probably connect to the bevy heirarchy with an Affine component
+pub struct VelloFragment(SceneFragment);
+
+#[derive(Component)]
+struct VelloScene(Scene, Handle<Image>);
+
+impl ExtractComponent for VelloScene {
+    type Query = (&'static VelloFragment, &'static VelloTarget);
+
+    type Filter = ();
+
+    type Out = Self;
+
+    fn extract_component(
+        (fragment, target): bevy::ecs::query::QueryItem<'_, Self::Query>,
+    ) -> Option<Self> {
+        let mut scene = Scene::default();
+        let mut builder = SceneBuilder::for_scene(&mut scene);
+        builder.append(&fragment.0, None);
+        Some(Self(scene, target.0.clone()))
+    }
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut images: ResMut<Assets<Image>>,
+) {
+    commands.spawn(Camera2dBundle::default());
+    let size = Extent3d {
+        width: 512,
+        height: 512,
+        ..default()
+    };
+
+    // This is the texture that will be rendered to.
+    let mut image = Image {
+        texture_descriptor: TextureDescriptor {
+            label: None,
+            size,
+            dimension: TextureDimension::D2,
+            format: TextureFormat::Rgba8Unorm,
+            mip_level_count: 1,
+            sample_count: 1,
+            usage: TextureUsages::TEXTURE_BINDING
+                | TextureUsages::COPY_DST
+                | TextureUsages::STORAGE_BINDING,
+            view_formats: &[],
+        },
+        ..default()
+    };
+
+    // fill image.data with zeroes
+    image.resize(size);
+
+    let x = 1;
+    let b = Box::new(&x);
+    take_box(b);
+    
+    let image_handle = images.add(image);
+    commands.spawn(SpriteBundle {
+        texture: image_handle.clone(),
+        transform: Transform::from_scale(Vec3::splat(0.5)),
+        ..default()
+    });
+    commands.spawn((
+        VelloFragment(SceneFragment::default()),
+        VelloTarget(image_handle),
+    ));
+}
+
+fn take_box(b: Box<&usize>) {
+
+}
+fn closure<'a, I: Iterator<Item = &'a str>, F: Fn(&'a str, usize, usize) -> I>(func: F) -> F {
+    func
+}
+fn get_card_score(line: &str) -> u32 {
+    // fn read_numbers(from: &str, starting: &usize, count: &usize) -> HashSet<&str> {
+    //     return HashSet::from_iter(
+    //         (0..count).map(|i| &from[starting + i * 3..starting + (i + 1) * 3]),
+    //     );
+    // }
+
+    let read_numbers = closure(|from, starting, count| {
+        (0..count).map(move |i| &from[starting + i * 3..starting + (i + 1) * 3])
+    });
+
+    let x = read_numbers("".into(), 1, 2);
+
+    // let numbers = ;
+    let numbers: HashSet<&str> = HashSet::from_iter(read_numbers(line, 10, 10));
+    let answers: HashSet<&str> = HashSet::from_iter(read_numbers(line, 42, 25));
+
+    return 0;
+}
+
+fn render_fragment(mut fragment: Query<&mut VelloFragment>) {
+    let mut fragment = fragment.single_mut();
+    let mut sb = SceneBuilder::for_fragment(&mut fragment.0);
+    let dark = Color::rgb(0.2, 0.2, 0.2);
+    let light = Color::rgb(0.8, 0.8, 0.8);
+    // let linear =  Gradient::new_linear((0.0, 0.0), (0.0, 200.0)).with_stops([
+    //     Color::RED,
+    //     Color::GREEN,
+    //     Color::BLUE,
+    // ]);
+    let x = |a, b| {
+        (a..b).map(|x| x + 1)
+    };
+    let c = x(0, 2);
+    sb.fill(
+        Fill::NonZero,
+        Affine::IDENTITY,
+        &light,
+        None,
+        &Rect::new(128., 128., 512. - 128., 512. - 128.).to_rounded_rect(32.),
+    );
+    sb.stroke(
+        &Stroke::new(8.),
+        Affine::IDENTITY,
+        &dark,
+        None,
+        // &Rect::new(128., 128., 512. - 128., 512. - 128.),
+        &Rect::new(128., 128., 512. - 128., 512. - 128.).to_rounded_rect(32.),
+    );
+}

--- a/crates/polako_ui/src/lib.rs
+++ b/crates/polako_ui/src/lib.rs
@@ -1,0 +1,469 @@
+use bevy::{prelude::{DerefMut, Deref}, math::Vec2, ecs::{component::Component, query::{WorldQuery, Without, With, Changed, Or}, system::{Query, Resource, Commands, ResMut, Local, Res}, entity::{Entity, Entities}, removal_detection::RemovedComponents}, hierarchy::{Children, Parent}, utils::{HashMap, HashSet}, window::{Window, PrimaryWindow}, log::warn};
+use polako_channel::Channel;
+// use taffy::
+
+#[derive(Component)]
+pub enum StyleProp<T> {
+    Undefined(T),
+    Defined(T),
+    Managed(T),
+}
+
+pub trait StylePropData: Default + Send + Sync + ApplyChange + 'static { }
+impl<T: Default + Send + Sync + ApplyChange + 'static> StylePropData for T { }
+
+#[derive(Component)]
+pub struct Inline;
+
+pub enum StylePropValue<'p, T> {
+    Ref(&'p StyleProp<T>),
+    Val(StyleProp<T>),
+}
+
+
+impl<'p, T> std::ops::Deref for StylePropValue<'p, T> {
+    type Target = StyleProp<T>;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            StylePropValue::Ref(prop) => prop,
+            StylePropValue::Val(prop) => prop,
+        }
+    }
+}
+
+pub struct StyleChange(Box<dyn FnOnce(&mut taffy::style::Style)>);
+unsafe impl Send for StyleChange { }
+unsafe impl Sync for StyleChange { }
+// pub struct StyleChanges(Vec<StyleChange>)
+
+#[derive(Component)]
+pub enum Owner {
+    Undefined,
+    Direct(Entity),
+    Page(Entity),
+    Space(Entity),
+}
+
+impl Owner {
+    pub fn space(&mut self, space: Entity) {
+        *self = Owner::Space(space)
+    }
+    pub fn page(&mut self, page: Entity) {
+        *self = Owner::Page(page)
+    }
+    pub fn direct(&mut self, parent: Entity) {
+        *self = Owner::Direct(parent)
+    }
+    pub fn undefined(&mut self) {
+        *self = Owner::Undefined;
+    }
+}
+
+pub trait ApplyChange {
+    fn apply_change(&self) -> StyleChange;
+}
+
+pub trait AsStylePropValue<T> {
+    fn as_style_prop(&self) -> StylePropValue<T>;
+}
+
+impl<'a, T: Default> AsStylePropValue<T> for Option<&'a StyleProp<T>> {
+    fn as_style_prop(&self) -> StylePropValue<T> {
+        match self {
+            Some(prop) => {
+                StylePropValue::Ref(prop)
+            },
+            None => StylePropValue::Val(StyleProp::Undefined(T::default()))
+        }
+    }
+}
+
+impl<T> std::ops::Deref for StyleProp<T> {
+    type Target = T;
+    fn deref(&self) -> &Self::Target {
+        match self {
+            StyleProp::Undefined(p) => p,
+            StyleProp::Defined(p) => p,
+            StyleProp::Managed(p) => p,
+        }
+    }
+}
+
+#[derive(WorldQuery)]
+pub struct StyleProps {
+    container: &'static StyleProp<Container>,
+    padding: Option<&'static StyleProp<Padding>>,
+    width: Option<&'static StyleProp<Width>>,
+    height: Option<&'static StyleProp<Height>>,
+}
+
+
+pub enum Container {
+    Stack,
+    Flex,
+    Space(TargetSpace),
+    Page,
+}
+
+impl Container {
+    pub fn is_stack(&self) -> bool {
+        matches!(self, Container::Stack)
+    }
+}
+
+pub enum TargetSpace {
+    Nearest,
+    Exact(Entity),
+}
+
+#[derive(Component)]
+pub struct Space {
+    pub width: u16,
+    pub height: u16,
+}
+
+#[derive(Component)]
+pub struct ComputedSpace(Entity);
+
+pub fn update_windows_space(
+    windows: Query<(Entity, &Window), Changed<Window>>,
+    mut spaces: Query<&mut Space>,
+    mut commands: Commands,
+) {
+    for (entity, window) in &windows {
+        let width = window.resolution.physical_height() as u16;
+        let height = window.resolution.physical_height() as u16;
+        if let Ok(mut space) = spaces.get_mut(entity) {
+            if space.width != width {
+                space.width = width;
+            }
+            if space.height != height {
+                space.height = height;
+            }
+        } else {
+            commands.entity(entity).insert(Space { width, height });
+        }
+    }
+}
+
+#[derive(Deref, DerefMut)]
+pub struct Padding(UiRect);
+impl Padding {
+    pub fn all(size: Val) -> Self {
+        Padding(UiRect { left: size, right: size, top: size, bottom: size })
+    }
+}
+impl Default for Padding {
+    fn default() -> Self {
+        Padding::all(Val::Px(0))
+    }
+}
+impl ApplyChange for Padding {
+    fn apply_change(&self) -> StyleChange {
+        let padding = self.0.clone();
+        StyleChange(Box::new(move |style| {
+            style.padding.left = padding.left.as_length_percentage();
+            style.padding.right = padding.right.as_length_percentage();
+            style.padding.top = padding.top.as_length_percentage();
+            style.padding.bottom = padding.bottom.as_length_percentage();
+        }))
+    }
+}
+
+
+#[derive(Clone, Copy, Deref, DerefMut)]
+pub struct Width(Val);
+impl Default for Width {
+    fn default() -> Self {
+        Width(Val::Auto)
+    }
+}
+
+impl ApplyChange for Width {
+    fn apply_change(&self) -> StyleChange {
+        let width = self.0.clone();
+        StyleChange(Box::new(move |style| {
+            style.size.width = width.as_dimension();
+        }))
+    }
+}
+
+#[derive(Clone, Copy, Deref, DerefMut)]
+pub struct Height(Val);
+impl Default for Height {
+    fn default() -> Self {
+        Height(Val::Auto)
+    }
+}
+
+impl ApplyChange for Height {
+    fn apply_change(&self) -> StyleChange {
+        let height = self.0.clone();
+        StyleChange(Box::new(move |style| {
+            style.size.height = height.as_dimension();
+        }))
+    }
+}
+
+
+#[derive(Clone, Copy, Debug)]
+pub enum Val {
+    Auto,
+    Px(i32),
+    Percent(f32)
+}
+
+impl Val {
+    pub fn as_length_percentage(&self) -> taffy::style::LengthPercentage {
+        match self {
+            Val::Auto => taffy::style::LengthPercentage::Points(0.),
+            Val::Percent(p) => taffy::style::LengthPercentage::Percent(*p),
+            Val::Px(p) => taffy::style::LengthPercentage::Points(*p as f32),
+        }
+    }
+    pub fn as_dimension(&self) -> taffy::style::Dimension {
+        match self {
+            Val::Auto => taffy::style::Dimension::Auto,
+            Val::Percent(p) => taffy::style::Dimension::Percent(*p),
+            Val::Px(p) => taffy::style::Dimension::Points(*p as f32),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct UiRect {
+    pub left: Val,
+    pub right: Val,
+    pub top: Val,
+    pub bottom: Val,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct UiSize {
+    pub width: Val,
+    pub height: Val,
+}
+
+#[derive(Component)]
+pub struct Node {
+    pub size: Vec2
+}
+
+#[derive(Resource)]
+pub struct UiSurface {
+    tree: taffy::Taffy,
+    entity_to_taffy: HashMap<Entity, taffy::node::Node>,
+}
+
+impl UiSurface {
+    pub fn update_space(&mut self, entity: Entity, space: &Space) {
+        let style = taffy::style::Style {
+            size: taffy::geometry::Size::from_points(space.width as f32, space.height as f32),
+            ..Default::default()
+        };
+        if let Some(node) = self.entity_to_taffy.get(&entity) {
+            self.tree.set_style(*node, style).unwrap();
+        } else {
+            let node = self.tree.new_leaf(style).unwrap();
+            self.entity_to_taffy.insert(entity, node);
+        }
+    }
+
+    pub fn edit_style<F: FnOnce(&mut taffy::style::Style)>(&mut self, entity: Entity, edit: F) {
+        if let Some(node) = self.entity_to_taffy.get(&entity) {
+            let mut style = self.tree.style(*node).unwrap().clone();
+            edit(&mut style);
+            self.tree.set_style(*node, style);
+        } else {
+            let mut style = taffy::style::Style::default();
+            edit(&mut style);
+            let node = self.tree.new_leaf(style).unwrap();
+            self.entity_to_taffy.insert(entity, node);
+        }
+    }
+
+    pub fn compute(&mut self) {
+        let node = self.tree.new_leaf(taffy::style::Style::default()).unwrap();
+        let x = self.tree.layout(node).unwrap();
+    }
+}
+
+impl Default for UiSurface {
+    fn default() -> Self {
+        UiSurface {
+            tree: taffy::Taffy::new(),
+            entity_to_taffy: HashMap::new(),
+        }
+    }
+}
+
+pub fn collect_prop_changes<T: StylePropData>(
+    changed: Query<(Entity, &StyleProp<T>), Changed<StyleProp<T>>>,
+    changes: Res<Channel<(Entity, StyleChange)>>,
+) {
+    for (entity, prop) in &changed {
+        changes.send((entity, prop.apply_change()))
+    }
+}
+
+pub fn collect_prop_removals<T: StylePropData>(
+    mut removed: RemovedComponents<StyleProp<T>>,
+    entities: Entities,
+    changes: Res<Channel<(Entity, StyleChange)>>,
+) {
+    for entity in removed.read() {
+        if entities.contains(entity) {
+            let change = T::default().apply_change();
+            changes.send((entity, change))
+        }
+    }
+}
+
+pub fn apply_changes(
+    mut changes: ResMut<Channel<(Entity, StyleChange)>>,
+    mut changed_entities: Local<HashMap<Entity, Vec<StyleChange>>>,
+    mut surface: ResMut<UiSurface>,
+) {
+    changes.consume(|(entity, change)| {
+        changed_entities.entry(entity).or_default().push(change)
+    });
+    for (entity, changes) in changed_entities.drain() {
+        surface.edit_style(entity, move |style| {
+            for change in changes {
+                change.0(style)
+            }
+        })
+    }
+}
+
+pub fn compute_owners(
+    space_tree: Query<(Option<&Parent>, Option<&Space>)>,
+    page_tree: Query<(Option<&Parent>, &StyleProp<Container>)>,
+    primary_window: Query<Entity, With<PrimaryWindow>>,
+    mut owners: Query<&mut Owner>,
+    changed: Query<
+        (Entity, Option<&Parent>, &StyleProp<Container>, Option<&Inline>),
+        Or<(Changed<Parent>, Changed<StyleProp<Container>>)>
+    >
+) {
+    fn nearest_space(
+        this: Entity,
+        primary_window: Entity,
+        tree: &Query<(Option<&Parent>, Option<&Space>)>
+    ) -> Entity {
+        let (parent, space) = tree.get(this).unwrap();
+        if space.is_some() {
+            this
+        } else if parent.is_none() {
+            primary_window
+        } else {
+            nearest_space(parent.unwrap().get(), primary_window, tree)
+        }
+    }
+    fn nearest_page(
+        this: Entity,
+        tree: &Query<(Option<&Parent>, &StyleProp<Container>)>
+    ) -> Entity {
+        let (parent, cnt) = tree.get(this).unwrap();
+        if matches!(**cnt, Container::Page) {
+            this
+        } else if let Some(parent) = parent {
+            nearest_page(parent.get(), tree)
+        } else {
+            panic!("Can't find nearest page.")
+        }
+    }
+    let primary_window = primary_window.single();
+    for (entity, parent, container, inline) in &changed {
+        match **container {
+            Container::Space(TargetSpace::Nearest) => {
+                owners.get_mut(entity).unwrap().space(nearest_space(entity, primary_window, &space_tree))
+            },
+            Container::Space(TargetSpace::Exact(space)) => {
+                owners.get_mut(entity).unwrap().space(space)
+            },
+            _ if inline.is_some() => {
+                owners.get_mut(entity).unwrap().page(nearest_page(entity, &page_tree))
+            },
+            _ if parent.is_some() => {
+                owners.get_mut(entity).unwrap().direct(parent.unwrap().get())
+            },
+            _ => {
+                warn!("Can't detect owner");
+                owners.get_mut(entity).unwrap().undefined();
+            }
+        }
+    }
+}
+
+pub fn compute_spaces_ineffective(
+    q_primary_window: Query<Entity, With<PrimaryWindow>>,
+    q_roots: Query<(Entity, &StyleProp<Container>), Without<Parent>>,
+    q_containers: Query<&StyleProp<Container>>,
+    mut q_computed: Query<&mut ComputedSpace>,
+    q_children: Query<&Children>,
+    mut commands: Commands,
+) {
+    let primary = q_primary_window.single();
+    fn set_space(
+        entity: Entity,
+        space: Entity,
+        containers: &Query<&StyleProp<Container>>,
+        computed: &mut Query<&mut ComputedSpace>,
+        children: &Query<&Children>,
+        commands: &mut Commands,
+    ) {
+        if let Ok(mut computed) = computed.get_mut(entity) {
+            if computed.0 != space {
+                computed.0 = space;
+            }
+        } else {
+            commands.entity(entity).insert(ComputedSpace(space));
+        }
+        let Ok(container) = containers.get(entity) else {
+            return;
+        };
+        let space = match **container {
+            Container::Space(TargetSpace::Exact(space)) => space,
+            _ => space
+        };
+        if let Ok(entities) = children.get(entity) {
+            for child in entities.iter() {
+                set_space(*child, space, containers, computed, children, commands)
+            }
+        }
+    }
+    for (entity, root) in &q_roots {
+        let space = match **root {
+            Container::Space(TargetSpace::Exact(entity)) => entity,
+            _ => primary
+        };
+        set_space(entity, space, &q_containers, &mut q_computed, &q_children, &mut commands)
+    }
+
+}
+
+pub fn process_spaces(
+    q_spaces: Query<(Entity, &Space), Changed<Space>>,
+    mut surface: ResMut<UiSurface>    
+) {
+    for (entity, space) in &q_spaces {
+        surface.update_space(entity, space)
+    }
+}
+
+
+pub fn process_ui(
+    q_roots: Query<(Entity, &Children), (With<Node>, Without<Parent>)>,
+    q_children: Query<&Children>,
+    q_props: Query<StyleProps>,
+) {
+    // for (root, children) in &q_roots {
+    //     let props = q_props.get(root).unwrap();
+    //     let padding = props.padding.as_style_prop();
+    //     let l = taffy::tree::layout::Layout::new();
+    //     // l.
+        
+    // }
+
+}

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -8,6 +8,13 @@ pub struct Pressed {
     entity: Entity
 }
 
+#[derive(Signal)]
+pub struct TakeDamageSignal {
+    entity: Entity,
+    amount: f32,
+    kind: u8,
+}
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
@@ -38,6 +45,9 @@ fn main() {
 
     /// Emits when there is pointer motion on the top of the div
     motion: MotionSignal,
+
+    /// When damage taken
+    take_damage: TakeDamageSignal,
 )]
 pub struct Div {
     #[prop(construct)]
@@ -80,6 +90,7 @@ fn hello_world(mut commands: Commands) {
                     .on.update: (e) => {
                         if time.elapsed > 1. && time.elapsed <= 2. {
                             info("1..2");
+                            delta.take_damage.emit(.amount: time.elapsed);
                         } else if -time.elapsed > -(1.0) {
                             info("< 1");
                         }
@@ -92,7 +103,13 @@ fn hello_world(mut commands: Commands) {
                         info("motioning");
                     }
                 } [
-                    delta: Label { .text: "0.0000" },
+                    delta: Label { 
+                        .text: "0.0000",
+                        .on.take_damage: (e) => {
+                            info("taking damage {}", e.amount);
+                            // info("taking damage");
+                        }
+                    },
                     elapsed: Label { .text: "0.00" },
                 ]
             ]

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -53,25 +53,33 @@ impl ElementBuilder for Label {
     }
 }
 
+#[derive(Default)]
+pub struct Dummy;
+
 fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.add(
         eml! {
             resource(time, Time);
-            Body {
-                .on.update: (e) => {
-                    delta.text = e.delta.fmt("Frame time: {:0.4}");
-                    elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");
-                    elapsed.bg.g = (time.elapsed - 2.) * 0.5;
-                },
-            } [
-                Column [
+            Body [
+                Column {
+                    .on.enter: () => {
+                        info("Column enters.");
+                    },
+                    .on.update: (e) => {
+                        delta.text = e.delta.fmt("Frame time: {:0.4}");
+                        elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");
+                        elapsed.bg.g = (time.elapsed - 2.) * 0.5;
+                        // info("Updated with delta = {:0.4}s", e.delta);
+                    },
+                } [
                     delta: Label { .text: "0.0000" },
                     elapsed: Label { .text: "0.00" },
                 ]
             ]
         }
     );
+
 }
 
 // Expanded `.on.update: () => { ... }`

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -78,8 +78,8 @@ fn hello_world(mut commands: Commands) {
                         info("Column enters.");
                     },
                     .on.update: (e) => {
-                        if time.elapsed > 2. {
-                            info("> 2");
+                        if time.elapsed > 1. && time.elapsed <= 2. {
+                            info("1..2");
                         } else if time.elapsed < 1.0 {
                             info("< 1");
                         }

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -20,6 +20,7 @@ fn main() {
             ..default()
         }))
         .add_plugins(FlowPlugin)
+        .add_plugins(PolakoInputPlugin)
         .add_systems(Startup, hello_world)
         .add_systems(Update, ui_text_system)
         .add_systems(Update, div_system)
@@ -28,6 +29,16 @@ fn main() {
 
 #[derive(Element)]
 #[construct(Div -> Empty)]
+#[signals(
+    /// Emits when pointer enters the div's rect
+    hover: HoverSignal,
+
+    /// Emits when div become focused
+    focus: FocusSignal,
+
+    /// Emits when there is pointer motion on the top of the div
+    motion: MotionSignal,
+)]
 pub struct Div {
     #[prop(construct)]
     /// The background color of element
@@ -72,6 +83,9 @@ fn hello_world(mut commands: Commands) {
                         elapsed.bg.g = (time.elapsed - 2.) * 0.5;
                         // info("Updated with delta = {:0.4}s", e.delta);
                     },
+                    .on.motion: () => {
+                        info("motioning");
+                    }
                 } [
                     delta: Label { .text: "0.0000" },
                     elapsed: Label { .text: "0.00" },
@@ -260,7 +274,10 @@ impl DivDesign {
 }
 
 use polako_flow::input::HoverSignal;
+use polako_flow::input::FocusSignal;
+use polako_flow::input::MotionSignal;
 use polako_flow::Signal;
+use polako_input::PolakoInputPlugin;
 pub struct Signals;
 impl Signals {
     pub fn hover(&self) -> &'static <HoverSignal as Signal>::Descriptor {

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -282,7 +282,7 @@ impl ElementBuilder for Row {
     }
 }
 
-use bevy::ecs::world::EntityMut;
+use bevy::ecs::world::EntityWorldMut;
 use polako_constructivism::Is;
 use polako_constructivism::Singleton;
 impl DivDesign {
@@ -337,9 +337,9 @@ impl Styles {
         })
     }
 }
-pub struct StyleProperty<T>(fn(&mut EntityMut, T));
+pub struct StyleProperty<T>(fn(&mut EntityWorldMut, T));
 impl<T> StyleProperty<T> {
-    pub fn assign<'w>(&self, entity: &mut EntityMut<'w>, value: T) {
+    pub fn assign<'w>(&self, entity: &mut EntityWorldMut<'w>, value: T) {
         (self.0)(entity, value)
     }
 }

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -80,7 +80,7 @@ fn hello_world(mut commands: Commands) {
                     .on.update: (e) => {
                         if time.elapsed > 1. && time.elapsed <= 2. {
                             info("1..2");
-                        } else if time.elapsed < 1.0 {
+                        } else if -time.elapsed > -(1.0) {
                             info("< 1");
                         }
                         delta.text = e.delta.fmt("Frame time: {:0.4}");

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -32,25 +32,27 @@ fn main() {
 
 fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
-    commands.add(eml! {
-        resource(time, Time);
-        bind(time.elapsed.fmt("{:0.2}") => elapsed.text);
-        bind(time.elapsed * 0.5 - 0.5 => content.bg.r);
-        bind(content.bg.hex => color.text);
-        Body + Name { .value: "body" } [
-            content: Column { .bg: #9d9d9d, .s.padding: [25, 50] }[
-                Div { .bg: #dedede, .s.padding: 50 } [
-                    "Hello world!"
-                ],
-                Row [
-                    "Elapsed: ", elapsed: Label { .text: "0.00" }
-                ],
-                Row [
-                    "Color: ", color: Label
+    commands.add(
+        eml! {
+            resource(time, Time);
+            Body {
+                .on.enter: () => {
+                    hello.text = "Hello, ";
+                },
+                .on.update: (e) => {
+                    delta.text = e.delta.fmt("Frame time: {:0.4}");
+                    elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");
+                    elapsed.bg.g = (time.elapsed - 2.) * 0.5;
+                },
+            } [
+                Column [
+                    Row [ hello: Label { .text: "..., " }, "world!" ],
+                    delta: Label { .text: "0.0000" },
+                    elapsed: Label { .text: "0.00" },
                 ]
             ]
-        ]
-    });
+        }
+    );
 }
 
 #[derive(Element)]

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -5,7 +5,7 @@ use polako::flow::*;
 
 #[derive(Signal)]
 pub struct Pressed {
-    entity: Entity
+    entity: Entity,
 }
 
 #[derive(Signal)]
@@ -79,123 +79,141 @@ pub struct Dummy;
 
 fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
-    commands.add(
-        eml! {
-            resource(time, Time);
-            Body [
-                Column {
-                    .on.enter: () => {
-                        info("Column enters.");
-                    },
-                    .on.update: (e) => {
-                        if time.elapsed > 1. && time.elapsed <= 2. {
-                            info("1..2");
-                            delta.take_damage.emit(.amount: time.elapsed);
-                        } else if -time.elapsed > -(1.0) {
-                            info("< 1");
-                        }
-                        delta.text = e.delta.fmt("Frame time: {:0.4}");
-                        elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");
-                        elapsed.bg.g = (time.elapsed - 2.) * 0.5;
-                        // info("Updated with delta = {:0.4}s", e.delta);
-                    },
-                    .on.motion: () => {
-                        info("motioning");
+    commands.add(eml! {
+        resource(time, Time);
+        Body [
+            Column {
+                .on.enter: () => {
+                    info("Column enters.");
+                },
+                .on.update: (e) => {
+                    if time.elapsed > 1. && time.elapsed <= 2. {
+                        info("1..2");
+                        delta.take_damage.emit(.amount: time.elapsed);
+                    } else if -time.elapsed > -(1.0) {
+                        info("< 1");
                     }
-                } [
-                    delta: Label { 
-                        .text: "0.0000",
-                        .on.take_damage: (e) => {
-                            info("taking damage {}", e.amount);
-                            // info("taking damage");
-                        }
-                    },
-                    elapsed: Label { .text: "0.00" },
-                ]
+                    delta.text = e.delta.fmt("Frame time: {:0.4}");
+                    elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");
+                    elapsed.bg.g = (time.elapsed - 2.) * 0.5;
+                    // info("Updated with delta = {:0.4}s", e.delta);
+                },
+                .on.motion: () => {
+                    info("motioning");
+                }
+            } [
+                delta: Label {
+                    .text: "0.0000",
+                    .on.take_damage: (e) => {
+                        info("taking damage {}", e.amount);
+                        // info("taking damage");
+                    }
+                },
+                elapsed: Label { .text: "0.00" },
             ]
-        }
-    );
-
+        ]
+    });
 }
 
 // Expanded `.on.update: () => { ... }`
-use polako_eml::EntityMark;
 use polako_constructivism::*;
+use polako_eml::EntityMark;
 fn _expand(world: &mut World) {
     let mut __entity__ = world.spawn_empty();
     let entity = __entity__.id();
     let elapsed = EntityMark::<Label>::new(entity);
     let delta = EntityMark::<Label>::new(entity);
     let time = ResourceMark::<Time>::new();
-    
-    let __ext__ =  <<Body as Construct>::Design as Singleton>::instance().on().update();
-    __ext__.assign(&mut __entity__, move |
-        e: &_,                  // infers as &UpdateSignal
-        _params: &mut StaticSystemParam<(
-            Commands, ParamSet<(
-                Query<&mut _>,  // infers as Query<&mut UiText>
-                Res<_>,         // infers as Res<Time>
-                Query<&mut _>,  // infers as Query<&mut Div>
-            )> 
-        ,)>
-    |{
-        let (_commands,_params) =  ::std::ops::DerefMut::deref_mut(_params);
-        let _v_time_elapsed = {
-            let _host = _params.p1();
-            time.getters().elapsed(&_host).into_value().get()
-        };
-        let _v_delta_text = {
-            let _inset = _params.p0();
-            let _mut = _inset.get(delta.entity).unwrap();
-            let _host =  &_mut;
-            delta.getters().text(&_host).into_value().get()
-        };
-        let _v_e_delta = {
-            let _host = e;
-            e.getters().delta(&_host).into_value().get()
-        };
-        let _v_elapsed_text = {
-            let _inset = _params.p0();
-            let _mut = _inset.get(elapsed.entity).unwrap();
-            let _host =  &_mut;
-            elapsed.getters().text(&_host).into_value().get()
-        };
-        let _v_elapsed_bg_g = {
-            let _inset = _params.p2();
-            let _mut = _inset.get(elapsed.entity).unwrap();
-            let _host =  &_mut;
-            elapsed.getters().bg(&_host).g().into_value().get()
-        };
-        {
-            let _val = ({
-                let res = format!("Frame time: {:0.4}",_v_e_delta);
-                res
-            }).into();
-            if _v_delta_text!=_val {
-                delta.setters().set_text(_params.p0().get_mut(delta.entity).unwrap().as_mut(),_val);
-                delta.descriptor().text().notify_changed(_commands,delta.entity);
-            }
-        };
-        {
-            let _val = ({
-                let res = format!("Elapsed time: {:0.2}",_v_time_elapsed);
-                res
-            }).into();
-            if _v_elapsed_text != _val {
-                elapsed.setters().set_text(_params.p0().get_mut(elapsed.entity).unwrap().as_mut(),_val);
-                elapsed.descriptor().text().notify_changed(_commands,elapsed.entity);
-            }
-        };
-        {
-            let _val = ((_v_time_elapsed-2.)*0.5).into();
-            if _v_elapsed_bg_g != _val {
-                elapsed.setters().bg(_params.p2().get_mut(elapsed.entity).unwrap().as_mut()).set_g(_val);
-                elapsed.descriptor().bg().notify_changed(_commands,elapsed.entity);
-            }
-        };
-    });
-}
 
+    let __ext__ = <<Body as Construct>::Design as Singleton>::instance()
+        .on()
+        .update();
+    __ext__.assign(
+        &mut __entity__,
+        move |e: &_, // infers as &UpdateSignal
+              _params: &mut StaticSystemParam<(
+            Commands,
+            ParamSet<(
+                Query<&mut _>, // infers as Query<&mut UiText>
+                Res<_>,        // infers as Res<Time>
+                Query<&mut _>, // infers as Query<&mut Div>
+            )>,
+        )>| {
+            let (_commands, _params) = ::std::ops::DerefMut::deref_mut(_params);
+            let _v_time_elapsed = {
+                let _host = _params.p1();
+                time.getters().elapsed(&_host).into_value().get()
+            };
+            let _v_delta_text = {
+                let _inset = _params.p0();
+                let _mut = _inset.get(delta.entity).unwrap();
+                let _host = &_mut;
+                delta.getters().text(&_host).into_value().get()
+            };
+            let _v_e_delta = {
+                let _host = e;
+                e.getters().delta(&_host).into_value().get()
+            };
+            let _v_elapsed_text = {
+                let _inset = _params.p0();
+                let _mut = _inset.get(elapsed.entity).unwrap();
+                let _host = &_mut;
+                elapsed.getters().text(&_host).into_value().get()
+            };
+            let _v_elapsed_bg_g = {
+                let _inset = _params.p2();
+                let _mut = _inset.get(elapsed.entity).unwrap();
+                let _host = &_mut;
+                elapsed.getters().bg(&_host).g().into_value().get()
+            };
+            {
+                let _val = ({
+                    let res = format!("Frame time: {:0.4}", _v_e_delta);
+                    res
+                })
+                .into();
+                if _v_delta_text != _val {
+                    delta
+                        .setters()
+                        .set_text(_params.p0().get_mut(delta.entity).unwrap().as_mut(), _val);
+                    delta
+                        .descriptor()
+                        .text()
+                        .notify_changed(_commands, delta.entity);
+                }
+            };
+            {
+                let _val = ({
+                    let res = format!("Elapsed time: {:0.2}", _v_time_elapsed);
+                    res
+                })
+                .into();
+                if _v_elapsed_text != _val {
+                    elapsed
+                        .setters()
+                        .set_text(_params.p0().get_mut(elapsed.entity).unwrap().as_mut(), _val);
+                    elapsed
+                        .descriptor()
+                        .text()
+                        .notify_changed(_commands, elapsed.entity);
+                }
+            };
+            {
+                let _val = ((_v_time_elapsed - 2.) * 0.5).into();
+                if _v_elapsed_bg_g != _val {
+                    elapsed
+                        .setters()
+                        .bg(_params.p2().get_mut(elapsed.entity).unwrap().as_mut())
+                        .set_g(_val);
+                    elapsed
+                        .descriptor()
+                        .bg()
+                        .notify_changed(_commands, elapsed.entity);
+                }
+            };
+        },
+    );
+}
 
 impl ElementBuilder for Div {
     fn build_element(content: Vec<Entity>) -> Blueprint<Self> {
@@ -295,8 +313,8 @@ impl DivDesign {
     }
 }
 
-use polako_flow::input::HoverSignal;
 use polako_flow::input::FocusSignal;
+use polako_flow::input::HoverSignal;
 use polako_flow::input::MotionSignal;
 use polako_flow::Signal;
 use polako_input::PolakoInputPlugin;

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -78,10 +78,10 @@ fn hello_world(mut commands: Commands) {
                         info("Column enters.");
                     },
                     .on.update: (e) => {
-                        if time.elapsed.fmt("{:0.0}") == "2" {
-                            info("At 2 secs");
-                        } else if time.elapsed.fmt("{:0.0}") != "3" {
-                            info("Not at 3 secs");
+                        if time.elapsed > 2. {
+                            info("> 2");
+                        } else if time.elapsed < 1.0 {
+                            info("< 1");
                         }
                         delta.text = e.delta.fmt("Frame time: {:0.4}");
                         elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -78,6 +78,11 @@ fn hello_world(mut commands: Commands) {
                         info("Column enters.");
                     },
                     .on.update: (e) => {
+                        if time.elapsed.fmt("{:0.0}") == "2" {
+                            info("At 2 secs");
+                        } else if time.elapsed.fmt("{:0.0}") == "3" {
+                            info("At 3 secs");
+                        }
                         delta.text = e.delta.fmt("Frame time: {:0.4}");
                         elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");
                         elapsed.bg.g = (time.elapsed - 2.) * 0.5;

--- a/examples/hands.rs
+++ b/examples/hands.rs
@@ -80,8 +80,8 @@ fn hello_world(mut commands: Commands) {
                     .on.update: (e) => {
                         if time.elapsed.fmt("{:0.0}") == "2" {
                             info("At 2 secs");
-                        } else if time.elapsed.fmt("{:0.0}") == "3" {
-                            info("At 3 secs");
+                        } else if time.elapsed.fmt("{:0.0}") != "3" {
+                            info("Not at 3 secs");
                         }
                         delta.text = e.delta.fmt("Frame time: {:0.4}");
                         elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -20,84 +20,6 @@ fn main() {
         .run();
 }
 
-
-fn test_infer(world: &mut World) {
-    let entity = world.spawn_empty().id();
-    let system = move |items: Query<&_>| {
-        let item = items.get(entity).unwrap();
-        let data = prop!(Label.text).get(item).as_ref().clone();
-        info!("data: {data}");
-    };
-    // system.run((), world);
-
-    world.schedule_scope(Update, move |w, s| {
-        let mut system = IntoSystem::into_system(system);
-        system.initialize(w);
-        s.add_systems(system);
-    });
-
-}
-
-pub trait GetRefComponent<T: Component> {
-    fn get_c(&self, entity: Entity) -> &T;
-}
-
-
-impl<'w, 's, T: Component> GetRefComponent<T> for Query<'w, 's, &T, ()> {
-    fn get_c(&self, entity: Entity) -> &T {
-        self.get(entity).unwrap()
-    }
-}
-
-pub trait GetMutComponent<T: Component> {
-    fn get_c<'a>(&'a mut self, entity: Entity) -> &'a mut T;
-}
-
-impl<'w, 's, T: Component> GetMutComponent<T> for Query<'w, 's, &mut T, ()> {
-    fn get_c<'a>(&'a mut self, entity: Entity) -> &'a mut T{
-        self.get_mut(entity).unwrap().into_inner()
-    }
-}
-
-
-fn takes_mut(q: Query<&mut UiText>) {
-
-}
-
-fn takes_mut_item(item: &mut UiText) {
-    
-}
-
-// impl div_construct::Props<Get> {
-//     pub fn press(&self) { }
-// }
-
-fn test_infer_mutability(world: &mut World) {
-    let entity = world.spawn_empty().id();
-    let system = move |mut items: Query<_>| {
-        // let item = items.get(entity).unwrap();
-        // let c = items.get_c(entity);
-        takes_mut(items)
-        // <<Label as Construct>::Props<Lookup> as Singleton>::instance().setters().text(items.get_c(entity), "hello".to_string());
-        // items.get_component(entity), |c| {
-        //     let 
-        //     <<Label as Construct>::Props<Lookup> as Singleton>::instance().setters().text(c, "hello".to_string());
-        // })
-        // let data = <<Label as Construct>::Props as Singleton>::instance().setters().text(this__, value__)
-        //  prop!(Label.text).get(item).as_ref().clone();
-        // info!("data: {data}");
-    };
-    // system.run((), world);
-
-    // world.schedule_scope(Update, move |w, s| {
-    //     let mut system = IntoSystem::into_system(system);
-    //     system.initialize(w);
-    //     s.add_systems(system);
-    // });
-
-
-
-}
 fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.add(
@@ -226,7 +148,7 @@ fn hello_world(mut commands: Commands) {
     )
 }
 
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(Div -> Empty)]
 pub struct Div {
     #[prop(construct)]
@@ -251,7 +173,7 @@ pub struct UiText {
     pub text_color: Color,
 }
 
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(Label -> UiText -> Div)]
 pub struct Label;
 impl ElementBuilder for Label {
@@ -262,7 +184,7 @@ impl ElementBuilder for Label {
     }
 }
 
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(Body -> Div)]
 pub struct Body;
 impl ElementBuilder for Body {
@@ -281,7 +203,7 @@ impl ElementBuilder for Body {
     }
 }
 
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(Column -> Div)]
 pub struct Column;
 impl ElementBuilder for Column {
@@ -300,7 +222,7 @@ impl ElementBuilder for Column {
     }
 }
 
-#[derive(Component, Construct)]
+#[derive(Element)]
 #[construct(Row -> Div)]
 pub struct Row;
 impl ElementBuilder for Row {
@@ -320,10 +242,7 @@ impl ElementBuilder for Row {
 }
 
 use bevy::ecs::world::EntityMut;
-use polako_constructivism::Construct;
-use polako_constructivism::Get;
 use polako_constructivism::Is;
-use polako_constructivism::Lookup;
 use polako_constructivism::Singleton;
 impl DivDesign {
     // Div can accept string literals as content
@@ -338,7 +257,7 @@ impl DivDesign {
         Implemented
     }
     // Only Div and elements based on Div can be content of the Div
-    pub fn push_content<E: ElementBuilder + Is<Div>>(
+    pub fn push_content<E: Element + Is<Div>>(
         &self,
         _: &mut World,
         content: &mut Vec<Entity>,

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -21,6 +21,83 @@ fn main() {
 }
 
 
+fn test_infer(world: &mut World) {
+    let entity = world.spawn_empty().id();
+    let system = move |items: Query<&_>| {
+        let item = items.get(entity).unwrap();
+        let data = prop!(Label.text).get(item).as_ref().clone();
+        info!("data: {data}");
+    };
+    // system.run((), world);
+
+    world.schedule_scope(Update, move |w, s| {
+        let mut system = IntoSystem::into_system(system);
+        system.initialize(w);
+        s.add_systems(system);
+    });
+
+}
+
+pub trait GetRefComponent<T: Component> {
+    fn get_c(&self, entity: Entity) -> &T;
+}
+
+
+impl<'w, 's, T: Component> GetRefComponent<T> for Query<'w, 's, &T, ()> {
+    fn get_c(&self, entity: Entity) -> &T {
+        self.get(entity).unwrap()
+    }
+}
+
+pub trait GetMutComponent<T: Component> {
+    fn get_c<'a>(&'a mut self, entity: Entity) -> &'a mut T;
+}
+
+impl<'w, 's, T: Component> GetMutComponent<T> for Query<'w, 's, &mut T, ()> {
+    fn get_c<'a>(&'a mut self, entity: Entity) -> &'a mut T{
+        self.get_mut(entity).unwrap().into_inner()
+    }
+}
+
+
+fn takes_mut(q: Query<&mut UiText>) {
+
+}
+
+fn takes_mut_item(item: &mut UiText) {
+    
+}
+
+// impl div_construct::Props<Get> {
+//     pub fn press(&self) { }
+// }
+
+fn test_infer_mutability(world: &mut World) {
+    let entity = world.spawn_empty().id();
+    let system = move |mut items: Query<_>| {
+        // let item = items.get(entity).unwrap();
+        // let c = items.get_c(entity);
+        takes_mut(items)
+        // <<Label as Construct>::Props<Lookup> as Singleton>::instance().setters().text(items.get_c(entity), "hello".to_string());
+        // items.get_component(entity), |c| {
+        //     let 
+        //     <<Label as Construct>::Props<Lookup> as Singleton>::instance().setters().text(c, "hello".to_string());
+        // })
+        // let data = <<Label as Construct>::Props as Singleton>::instance().setters().text(this__, value__)
+        //  prop!(Label.text).get(item).as_ref().clone();
+        // info!("data: {data}");
+    };
+    // system.run((), world);
+
+    // world.schedule_scope(Update, move |w, s| {
+    //     let mut system = IntoSystem::into_system(system);
+    //     system.initialize(w);
+    //     s.add_systems(system);
+    // });
+
+
+
+}
 fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.add(eml! {
@@ -138,7 +215,11 @@ impl Element for Row {
 }
 
 use bevy::ecs::world::EntityMut;
+use polako_constructivism::Construct;
+use polako_constructivism::Get;
 use polako_constructivism::Is;
+use polako_constructivism::Lookup;
+use polako_constructivism::Singleton;
 impl DivDesign {
     // Div can accept string literals as content
     pub fn push_text<'c, S: AsRef<str>>(

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -35,26 +35,20 @@ fn hello_world(mut commands: Commands) {
     commands.add(
         eml! {
             resource(time, Time);
-            Body [
+            Body {
+                .on.enter: () => {
+                    hello.text = "Hello, ";
+                },
+                .on.update: (e) => {
+                    delta.text = e.delta.fmt("{:0.4}");
+                    elapsed.text = time.elapsed.fmt("{:0.2}");
+                    elapsed.bg.g = time.elapsed * 0.2;
+                },
+            } [
                 Column [
-                    Div {
-                        .on.enter: () => {
-                            hello.text = "Hello, ";
-                        },
-                        .on.update: (e) => {
-                            delta.text = e.delta.fmt("{:0.4}");
-                        },
-                        .on.update: () => {
-                            elapsed.text = time.elapsed.fmt("{:0.2}");
-                            // elapsed.text = time.elapsed * 0.25 -> "{:0.2}";
-                            // elapsed.text = (time.elapsed * 0.25).fmt("{:0.2}");
-                        },
-                        .bg: #2d2d2d,
-                    },
                     Row [ hello: Label { .text: "..., " }, "world!" ],
                     Row [ "Frame time: ", delta: Label { .text: "0.0000" } ],
                     Row [ "Elapsed time: ", elapsed: Label { .text: "0.00" } ],
-                    // Row [ "Elapsed time: ", Label { .bind.text.from: {{ time.elapsed.fmt(":0.2") }}}],
                 ]
             ]
         }

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,6 +1,3 @@
-use std::ops::DerefMut;
-
-use bevy::ecs::system::StaticSystemParam;
 use bevy::prelude::*;
 use polako::eml::*;
 use polako::flow::*;
@@ -70,7 +67,7 @@ impl ElementBuilder for Div {
     }
 }
 
-#[derive(Component, Behavior)]
+#[derive(Behavior)]
 pub struct UiText {
     /// The text value of UiText element.
     pub text: String,
@@ -189,7 +186,7 @@ pub struct Styles;
 impl Styles {
     /// The amount of space between the edges of a node and its contents in pixels.
     pub fn padding<T: IntoRect>(&self) -> StyleProperty<T> {
-        StyleProperty(|mut entity, padding| {
+        StyleProperty(|entity, padding| {
             let rect = padding.into_rect();
             if !entity.contains::<Style>() {
                 entity.insert(Style::default());

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -141,7 +141,7 @@ impl ElementBuilder for Row {
     }
 }
 
-use bevy::ecs::world::EntityMut;
+use bevy::ecs::world::EntityWorldMut;
 use polako_constructivism::Is;
 use polako_constructivism::Singleton;
 impl DivDesign {
@@ -193,9 +193,9 @@ impl Styles {
         })
     }
 }
-pub struct StyleProperty<T>(fn(&mut EntityMut, T));
+pub struct StyleProperty<T>(fn(&mut EntityWorldMut, T));
 impl<T> StyleProperty<T> {
-    pub fn assign<'w>(&self, entity: &mut EntityMut<'w>, value: T) {
+    pub fn assign<'w>(&self, entity: &mut EntityWorldMut<'w>, value: T) {
         (self.0)(entity, value)
     }
 }

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -44,10 +44,16 @@ fn hello_world(mut commands: Commands) {
                         .on.update: (e) => {
                             delta.text = e.delta.fmt("{:0.4}");
                         },
+                        .on.update: () => {
+                            elapsed.text = time.elapsed.fmt("{:0.2}");
+                            // elapsed.text = time.elapsed * 0.25 -> "{:0.2}";
+                            // elapsed.text = (time.elapsed * 0.25).fmt("{:0.2}");
+                        },
                         .bg: #2d2d2d,
                     },
                     Row [ hello: Label { .text: "..., " }, "world!" ],
                     Row [ "Frame time: ", delta: Label { .text: "0.0000" } ],
+                    Row [ "Elapsed time: ", elapsed: Label { .text: "0.00" } ],
                     // Row [ "Elapsed time: ", Label { .bind.text.from: {{ time.elapsed.fmt(":0.2") }}}],
                 ]
             ]
@@ -192,7 +198,7 @@ impl DivDesign {
         &self,
         _: &mut World,
         content: &mut Vec<Entity>,
-        model: Model<E>,
+        model: EntityMark<E>,
     ) -> Implemented {
         content.push(model.entity);
         Implemented

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -4,7 +4,7 @@ use polako::flow::*;
 
 #[derive(Signal)]
 pub struct Pressed {
-    entity: Entity
+    entity: Entity,
 }
 
 fn main() {
@@ -24,8 +24,6 @@ fn main() {
         .add_systems(Update, div_system)
         .run();
 }
-
-
 
 fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,5 +1,6 @@
 use std::ops::DerefMut;
 
+use bevy::ecs::system::StaticSystemParam;
 use bevy::prelude::*;
 use polako::eml::*;
 use polako::flow::*;
@@ -27,24 +28,33 @@ fn main() {
         .run();
 }
 
+
+
 fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.add(
         eml! {
+            // resource(time, Time);
             Body [
-                Div {
-                    // .on.hover: () => {
-                    //     label.text = source.text.fmt("{}, world!")
-                    // },
-                    .on.enter: () =>{
-                        label.text = "Hello, ";
+                Column [
+                    Div {
+                        // .on.hover: () => {
+                        //     label.text = source.text.fmt("{}, world!")
+                        // },
+                        .on.enter: () => {
+                            hello.text = "Hello, ";
+                        },
+                        // .on.update: () => {
+                        //     wrld.text = time.elapsed_seconds.fmt("{:0.2}");
+                        // },
+                        .bg: #2d2d2d,
                     },
-                    .bg: #2d2d2d,
-                },
-                label: Label { .text: "..., "},
-                "world!",
+                    Row [ hello: Label { .text: "..., " }, "world!" ],
+                    // wrld: Label { .text: "world!" },
+                ]
             ]
         }
+
     );
 
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -1,6 +1,13 @@
+use std::ops::DerefMut;
+
 use bevy::prelude::*;
 use polako::eml::*;
 use polako::flow::*;
+
+#[derive(Signal)]
+pub struct Pressed {
+    entity: Entity
+}
 
 fn main() {
     App::new()
@@ -26,126 +33,39 @@ fn hello_world(mut commands: Commands) {
         eml! {
             Body [
                 Div {
-                    .on.hover: () => {
-                        label.text = source.text.fmt("{}, world!")
+                    // .on.hover: () => {
+                    //     label.text = source.text.fmt("{}, world!")
+                    // },
+                    .on.enter: () =>{
+                        label.text = "Hello, ";
                     },
                     .bg: #2d2d2d,
                 },
-                source: Label { .text: "Hello, "},
-                label: Label,
-                "world",
+                label: Label { .text: "..., "},
+                "world!",
             ]
-            // resource(time, Time);
-            // bind(time.elapsed_seconds.fmt("{:0.2}") => elapsed.text);
-            // bind(time.elapsed_seconds * 0.5 - 0.5 => content.bg.r);
-            // bind(content.bg.hex => color.text);
-            // Body + Name { .value: "body" } [
-            //     content: Column { .bg: #9d9d9d, .s.padding: [25, 50] }[
-            //         Div { .bg: #dedede, .s.padding: 50 } [
-            //             "Hello world!"
-            //         ],
-            //         Row [
-            //             "Elapsed: ", elapsed: Label { .text: "0.00" }
-            //         ],
-            //         Row [
-            //             "Color: ", color: Label
-            //         ]
-            //     ]
-            // ]
         }
+    );
 
-        // Recursive expansion of eml! macro
-// ==================================
 
-// ::polako::eml::Eml:: <Body> ::new(move|world: &mut::bevy::prelude::World,__root__: ::bevy::prelude::Entity|{
-//     let __this__ = __root__;
-//     let label = world.spawn_empty().id();
-//     let label: ::polako::eml::Model<Label>  =  ::polako::eml::Model::new(label);
-//     let __root_model__ =  ::polako::eml::Model:: <Body> ::new(__root__);
-//     {
-//       let __model__ = {
-//         world.entity_mut(__root__).insert(::polako::eml::IntoBundle::into_bundle({
-//           use::polako::constructivism::traits:: * ;
-//           let fields =  <<Body as ::polako::constructivism::Construct> ::Params as ::polako::constructivism::Singleton> ::instance();
-//           let params =  <<Body as ::polako::constructivism::Construct> ::ExpandedParams as ::polako::constructivism::Extractable> ::as_params();
-//           let defined_params = params.defined();
-//           <Body as ::polako::constructivism::Construct> ::construct(defined_params)
-//         }));
-//         __root_model__
-//       };
-//       let __content__ = {
-//         let mut __content__ =  ::std::vec::Vec:: <_> ::new();
-//         __content__.reserve(2usize);
-//         let __content_item__ = {
-//           {
-//             let __model__ = {
-//               let __entity__ = world.spawn(::polako::eml::IntoBundle::into_bundle({
-//                 use::polako::constructivism::traits:: * ;
-//                 let fields =  <<Div as ::polako::constructivism::Construct> ::Params as ::polako::constructivism::Singleton> ::instance();
-//                 let params =  <<Div as ::polako::constructivism::Construct> ::ExpandedParams as ::polako::constructivism::Extractable> ::as_params();
-//                 let defined_params = params.defined();
-//                 <Div as ::polako::constructivism::Construct> ::construct(defined_params)
-//               })).id();
-//               ::polako::eml::Model:: <Div> ::new(__entity__)
-//             };
-//             let __content__ = {
-//               let mut __content__ =  ::std::vec::Vec:: <_> ::new();
-//               __content__.reserve(0usize);
-//               __content__
-//             };
-//             <Div as ::polako::eml::ElementBuilder> ::build_element(__content__).eml().write(world,__model__.entity);
-//             {
-//               let __entity__ = world.entity_mut(__model__.entity);
-//               {
-//                 let __ext__ =  <<Div as ::polako::constructivism::Construct> ::Design as ::polako::constructivism::Singleton> ::instance().on().hover();
-//                 __ext__.assign(__entity__, ::polako::flow::Hand::new(move|_params: &mut (::polako::bevy::prelude::Query< &mut _, ()> ,)| -> () {
-//                   let (_q0,) = _params;
-//                   {
-//                     let _value = ("hello!").into();
-//                     let mut _host = _q0.get_mut(label.entity).unwrap();
-//                     if<<Label as ::polako::constructivism::Construct> ::Props< ::polako::constructivism::Lookup>as ::polako::constructivism::Singleton> ::instance().getters().text(&_host).into_value().as_ref()!= &_value {
-//                       <<Label as ::polako::constructivism::Construct> ::Props< ::polako::constructivism::Lookup>as ::polako::constructivism::Singleton> ::instance().setters().set_text(_host.as_mut(),_value)
-//                     }
-//                   }
-//                 }));
-//               }
-//             }__model__
-//           }
-//         };
-//         let _:Implemented =  <<Body as ::polako::constructivism::Construct> ::Design as ::polako::constructivism::Singleton> ::instance().push_content(world, &mut __content__,__content_item__);
-//         let __content_item__ = {
-//           {
-//             let __model__ = {
-//               world.entity_mut(label.entity).insert(::polako::eml::IntoBundle::into_bundle({
-//                 use::polako::constructivism::traits:: * ;
-//                 let fields =  <<Label as ::polako::constructivism::Construct> ::Params as ::polako::constructivism::Singleton> ::instance();
-//                 let params =  <<Label as ::polako::constructivism::Construct> ::ExpandedParams as ::polako::constructivism::Extractable> ::as_params();
-//                 let defined_params = params.defined();
-//                 <Label as ::polako::constructivism::Construct> ::construct(defined_params)
-//               }));
-//               label
-//             };
-//             let __content__ = {
-//               let mut __content__ =  ::std::vec::Vec:: <_> ::new();
-//               __content__.reserve(0usize);
-//               __content__
-//             };
-//             <Label as ::polako::eml::ElementBuilder> ::build_element(__content__).eml().write(world,__model__.entity);
-//             {
-//               let __entity__ = world.entity_mut(__model__.entity);
-//             }__model__
-//           }
-//         };
-//         let _:Implemented =  <<Body as ::polako::constructivism::Construct> ::Design as ::polako::constructivism::Singleton> ::instance().push_content(world, &mut __content__,__content_item__);
-//         __content__
-//       };
-//       <Body as ::polako::eml::ElementBuilder> ::build_element(__content__).eml().write(world,__model__.entity);
-//       {
-//         let __entity__ = world.entity_mut(__model__.entity);
-//       }__model__
-//     };
-//   })
-    )
+        //     // resource(time, Time);
+        //     // bind(time.elapsed_seconds.fmt("{:0.2}") => elapsed.text);
+        //     // bind(time.elapsed_seconds * 0.5 - 0.5 => content.bg.r);
+        //     // bind(content.bg.hex => color.text);
+        //     // Body + Name { .value: "body" } [
+        //     //     content: Column { .bg: #9d9d9d, .s.padding: [25, 50] }[
+        //     //         Div { .bg: #dedede, .s.padding: 50 } [
+        //     //             "Hello world!"
+        //     //         ],
+        //     //         Row [
+        //     //             "Elapsed: ", elapsed: Label { .text: "0.00" }
+        //     //         ],
+        //     //         Row [
+        //     //             "Color: ", color: Label
+        //     //         ]
+        //     //     ]
+        //     // ]
+        // }
 }
 
 #[derive(Element)]
@@ -165,7 +85,7 @@ impl ElementBuilder for Div {
     }
 }
 
-#[derive(Component, Behaviour)]
+#[derive(Component, Behavior)]
 pub struct UiText {
     /// The text value of UiText element.
     pub text: String,
@@ -269,9 +189,6 @@ impl DivDesign {
     /// Everything based on Div can access the styles using param extensions: `Row { .s.padding: 25 }`
     pub fn s(&self) -> &'static Styles {
         &Styles
-    }
-    pub fn on(&self) -> &'static Signals {
-        &Signals
     }
 }
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -34,26 +34,27 @@ fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     commands.add(
         eml! {
-            // resource(time, Time);
+            resource(time, Time);
             Body [
                 Column [
                     Div {
-                        // .on.hover: () => {
-                        //     label.text = source.text.fmt("{}, world!")
-                        // },
                         .on.enter: () => {
                             hello.text = "Hello, ";
                         },
-                        // .on.update: () => {
-                        //     wrld.text = time.elapsed_seconds.fmt("{:0.2}");
-                        // },
+                        .on.update: (e) => {
+                            delta.text = e.delta.fmt("{:0.4}");
+                        },
                         .bg: #2d2d2d,
                     },
                     Row [ hello: Label { .text: "..., " }, "world!" ],
-                    // wrld: Label { .text: "world!" },
+                    Row [ "Frame time: ", delta: Label { .text: "0.0000" } ],
+                    // Row [ "Elapsed time: ", Label { .bind.text.from: {{ time.elapsed.fmt(":0.2") }}}],
                 ]
             ]
         }
+        
+
+
 
     );
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -100,25 +100,130 @@ fn test_infer_mutability(world: &mut World) {
 }
 fn hello_world(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
-    commands.add(eml! {
-        resource(time, Time);
-        bind(time.elapsed_seconds.fmt("{:0.2}") => elapsed.text);
-        bind(time.elapsed_seconds * 0.5 - 0.5 => content.bg.r);
-        bind(content.bg.hex => color.text);
-        Body + Name { .value: "body" } [
-            content: Column { .bg: #9d9d9d, .s.padding: [25, 50] }[
-                Div { .bg: #dedede, .s.padding: 50 } [
-                    "Hello world!"
-                ],
-                Row [
-                    "Elapsed: ", elapsed: Label { .text: "0.00" }
-                ],
-                Row [
-                    "Color: ", color: Label
-                ]
+    commands.add(
+        eml! {
+            Body [
+                Div {
+                    .on.hover: () => {
+                        label.text = source.text.fmt("{}, world!")
+                    },
+                    .bg: #2d2d2d,
+                },
+                source: Label { .text: "Hello, "},
+                label: Label,
+                "world",
             ]
-        ]
-    })
+            // resource(time, Time);
+            // bind(time.elapsed_seconds.fmt("{:0.2}") => elapsed.text);
+            // bind(time.elapsed_seconds * 0.5 - 0.5 => content.bg.r);
+            // bind(content.bg.hex => color.text);
+            // Body + Name { .value: "body" } [
+            //     content: Column { .bg: #9d9d9d, .s.padding: [25, 50] }[
+            //         Div { .bg: #dedede, .s.padding: 50 } [
+            //             "Hello world!"
+            //         ],
+            //         Row [
+            //             "Elapsed: ", elapsed: Label { .text: "0.00" }
+            //         ],
+            //         Row [
+            //             "Color: ", color: Label
+            //         ]
+            //     ]
+            // ]
+        }
+
+        // Recursive expansion of eml! macro
+// ==================================
+
+// ::polako::eml::Eml:: <Body> ::new(move|world: &mut::bevy::prelude::World,__root__: ::bevy::prelude::Entity|{
+//     let __this__ = __root__;
+//     let label = world.spawn_empty().id();
+//     let label: ::polako::eml::Model<Label>  =  ::polako::eml::Model::new(label);
+//     let __root_model__ =  ::polako::eml::Model:: <Body> ::new(__root__);
+//     {
+//       let __model__ = {
+//         world.entity_mut(__root__).insert(::polako::eml::IntoBundle::into_bundle({
+//           use::polako::constructivism::traits:: * ;
+//           let fields =  <<Body as ::polako::constructivism::Construct> ::Params as ::polako::constructivism::Singleton> ::instance();
+//           let params =  <<Body as ::polako::constructivism::Construct> ::ExpandedParams as ::polako::constructivism::Extractable> ::as_params();
+//           let defined_params = params.defined();
+//           <Body as ::polako::constructivism::Construct> ::construct(defined_params)
+//         }));
+//         __root_model__
+//       };
+//       let __content__ = {
+//         let mut __content__ =  ::std::vec::Vec:: <_> ::new();
+//         __content__.reserve(2usize);
+//         let __content_item__ = {
+//           {
+//             let __model__ = {
+//               let __entity__ = world.spawn(::polako::eml::IntoBundle::into_bundle({
+//                 use::polako::constructivism::traits:: * ;
+//                 let fields =  <<Div as ::polako::constructivism::Construct> ::Params as ::polako::constructivism::Singleton> ::instance();
+//                 let params =  <<Div as ::polako::constructivism::Construct> ::ExpandedParams as ::polako::constructivism::Extractable> ::as_params();
+//                 let defined_params = params.defined();
+//                 <Div as ::polako::constructivism::Construct> ::construct(defined_params)
+//               })).id();
+//               ::polako::eml::Model:: <Div> ::new(__entity__)
+//             };
+//             let __content__ = {
+//               let mut __content__ =  ::std::vec::Vec:: <_> ::new();
+//               __content__.reserve(0usize);
+//               __content__
+//             };
+//             <Div as ::polako::eml::ElementBuilder> ::build_element(__content__).eml().write(world,__model__.entity);
+//             {
+//               let __entity__ = world.entity_mut(__model__.entity);
+//               {
+//                 let __ext__ =  <<Div as ::polako::constructivism::Construct> ::Design as ::polako::constructivism::Singleton> ::instance().on().hover();
+//                 __ext__.assign(__entity__, ::polako::flow::Hand::new(move|_params: &mut (::polako::bevy::prelude::Query< &mut _, ()> ,)| -> () {
+//                   let (_q0,) = _params;
+//                   {
+//                     let _value = ("hello!").into();
+//                     let mut _host = _q0.get_mut(label.entity).unwrap();
+//                     if<<Label as ::polako::constructivism::Construct> ::Props< ::polako::constructivism::Lookup>as ::polako::constructivism::Singleton> ::instance().getters().text(&_host).into_value().as_ref()!= &_value {
+//                       <<Label as ::polako::constructivism::Construct> ::Props< ::polako::constructivism::Lookup>as ::polako::constructivism::Singleton> ::instance().setters().set_text(_host.as_mut(),_value)
+//                     }
+//                   }
+//                 }));
+//               }
+//             }__model__
+//           }
+//         };
+//         let _:Implemented =  <<Body as ::polako::constructivism::Construct> ::Design as ::polako::constructivism::Singleton> ::instance().push_content(world, &mut __content__,__content_item__);
+//         let __content_item__ = {
+//           {
+//             let __model__ = {
+//               world.entity_mut(label.entity).insert(::polako::eml::IntoBundle::into_bundle({
+//                 use::polako::constructivism::traits:: * ;
+//                 let fields =  <<Label as ::polako::constructivism::Construct> ::Params as ::polako::constructivism::Singleton> ::instance();
+//                 let params =  <<Label as ::polako::constructivism::Construct> ::ExpandedParams as ::polako::constructivism::Extractable> ::as_params();
+//                 let defined_params = params.defined();
+//                 <Label as ::polako::constructivism::Construct> ::construct(defined_params)
+//               }));
+//               label
+//             };
+//             let __content__ = {
+//               let mut __content__ =  ::std::vec::Vec:: <_> ::new();
+//               __content__.reserve(0usize);
+//               __content__
+//             };
+//             <Label as ::polako::eml::ElementBuilder> ::build_element(__content__).eml().write(world,__model__.entity);
+//             {
+//               let __entity__ = world.entity_mut(__model__.entity);
+//             }__model__
+//           }
+//         };
+//         let _:Implemented =  <<Body as ::polako::constructivism::Construct> ::Design as ::polako::constructivism::Singleton> ::instance().push_content(world, &mut __content__,__content_item__);
+//         __content__
+//       };
+//       <Body as ::polako::eml::ElementBuilder> ::build_element(__content__).eml().write(world,__model__.entity);
+//       {
+//         let __entity__ = world.entity_mut(__model__.entity);
+//       }__model__
+//     };
+//   })
+    )
 }
 
 #[derive(Component, Construct)]
@@ -128,7 +233,7 @@ pub struct Div {
     /// The background color of element
     bg: Color,
 }
-impl Element for Div {
+impl ElementBuilder for Div {
     fn build_element(content: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             Div::Base
@@ -149,7 +254,7 @@ pub struct UiText {
 #[derive(Component, Construct)]
 #[construct(Label -> UiText -> Div)]
 pub struct Label;
-impl Element for Label {
+impl ElementBuilder for Label {
     fn build_element(_: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             Label::Base + TextBundle
@@ -160,7 +265,7 @@ impl Element for Label {
 #[derive(Component, Construct)]
 #[construct(Body -> Div)]
 pub struct Body;
-impl Element for Body {
+impl ElementBuilder for Body {
     fn build_element(content: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             Body::Base
@@ -179,7 +284,7 @@ impl Element for Body {
 #[derive(Component, Construct)]
 #[construct(Column -> Div)]
 pub struct Column;
-impl Element for Column {
+impl ElementBuilder for Column {
     fn build_element(content: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             Column::Base
@@ -198,7 +303,7 @@ impl Element for Column {
 #[derive(Component, Construct)]
 #[construct(Row -> Div)]
 pub struct Row;
-impl Element for Row {
+impl ElementBuilder for Row {
     fn build_element(content: Vec<Entity>) -> Blueprint<Self> {
         blueprint! {
             Row::Base
@@ -233,7 +338,7 @@ impl DivDesign {
         Implemented
     }
     // Only Div and elements based on Div can be content of the Div
-    pub fn push_content<E: Element + Is<Div>>(
+    pub fn push_content<E: ElementBuilder + Is<Div>>(
         &self,
         _: &mut World,
         content: &mut Vec<Entity>,
@@ -246,8 +351,19 @@ impl DivDesign {
     pub fn s(&self) -> &'static Styles {
         &Styles
     }
+    pub fn on(&self) -> &'static Signals {
+        &Signals
+    }
 }
 
+use polako_flow::input::HoverSignal;
+use polako_flow::Signal;
+pub struct Signals;
+impl Signals {
+    pub fn hover(&self) -> &'static <HoverSignal as Signal>::Descriptor {
+        <<HoverSignal as Signal>::Descriptor as Singleton>::instance()
+    }
+}
 pub struct Styles;
 impl Styles {
     /// The amount of space between the edges of a node and its contents in pixels.

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -40,22 +40,18 @@ fn hello_world(mut commands: Commands) {
                     hello.text = "Hello, ";
                 },
                 .on.update: (e) => {
-                    delta.text = e.delta.fmt("{:0.4}");
-                    elapsed.text = time.elapsed.fmt("{:0.2}");
-                    elapsed.bg.g = time.elapsed * 0.2;
+                    delta.text = e.delta.fmt("Frame time: {:0.4}");
+                    elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");
+                    elapsed.bg.g = (time.elapsed - 2.) * 0.5;
                 },
             } [
                 Column [
                     Row [ hello: Label { .text: "..., " }, "world!" ],
-                    Row [ "Frame time: ", delta: Label { .text: "0.0000" } ],
-                    Row [ "Elapsed time: ", elapsed: Label { .text: "0.00" } ],
+                    delta: Label { .text: "0.0000" },
+                    elapsed: Label { .text: "0.00" },
                 ]
             ]
         }
-        
-
-
-
     );
 
 


### PR DESCRIPTION
This PR is abut to add `Signals` and `Hands` to Polako. See [hands](https://github.com/polako-rs/polako/blob/hands/examples/hands.rs) example.

### Signals

Signal is a wrapper around Event associated with Entity. There are user defined signals like `TakeDamageSignal` or system-provided signals like `OnDemand<EnterSignal>` or `OnDemand<UpdateSignal>`.

I can define Signal like this:
```rust
#[derive(Signal)]
pub struct TakeDamageSignal {
  entity: Entity,
  damage: f32
}
```

I can assign the Signal to the Element like this:
```rust
#[derive(Element)]
#[signal(take_damage: TakeDamageSignal)]
pub struct Enemy {
  health: f32
}
```

I can connect to Signal like this:
```rust
impl ElementBuilder for Div {
    fn build_element(content: Vec<Entity>) -> Blueprint<Self> {
        blueprint! {
            Enemy::Base { .on.take_damage: (e) => { this.health -= e.damage; } }
            [[ content ]]
        }
    }
}
```
- ` .on.take_damage: ` defines the signal to connect
- `(e) => { this.health -= e.damage; }` is the Hand.
I can emit event by sending the Signal to EventWriter, or by calling `enemy.take_damage.emit(.damage: 23.)` from the Hand.

### Hands

Hand is the Signal's handler. It looks like closure, but it is not. Hand is parsed manually. Hand have access to `eml` context and its marks. With this knowledge it is possible to build System with only required params for the exact Hand.  For example:

```rust
#[derive(Element)]
#[construct(Div -> Empty)]
pub struct Div {
  bg: Color
}

#[derive(Behavior)]
pub struct UiText {
  text: String
}

#[derive(Element)]
#[construct(Label -> UiText -> Div)]
pub struct Label;

commands.add!(eml! {
    resource(time, Time);
    Body {
        .on.update: (e) => {
            delta.text = e.delta.fmt("Frame time: {:0.4}");
            elapsed.text = time.elapsed.fmt("Elapsed time: {:0.2}");
            elapsed.bg.g = (time.elapsed - 2.) * 0.5;
        },
    } [
        Column [
            delta: Label { .text: "0.0000" },
            elapsed: Label { .text: "0.00" },
        ]
    ]
});
```

Expanded `eml!` will generate variables `time: ResourceMark<Time>`, `delta: EntityMark<Label>` and `elapsed: EntityMark<Label>`. EntityMark<T> is just an Entity with PhantomData<T>. 

The expanded eml will also generate a system-like closure that requests only required system params for this hand. It looks something like this:
```rust
let __ext__ =  <<Body as Construct>::Design as Singleton>::instance().on().update();
__ext__.assign(&mut __entity__, move |
    e: &_,                  // infers as &UpdateSignal
    _params: &mut StaticSystemParam<(
        Commands, ParamSet<(
            Query<&mut _>,  // infers as Query<&mut UiText>
            Res<_>,         // infers as Res<Time>
            Query<&mut _>,  // infers as Query<&mut Div>
        )> 
    ,)>
|{
    let (_commands,_params) =  ::std::ops::DerefMut::deref_mut(_params);
    
    // read all required values
    let _v_time_elapsed = {
        let _host = _params.p1();
        time.getters().elapsed(&_host).into_value().get()
    };
    let _v_delta_text = {
        let _inset = _params.p0();
        let _mut = _inset.get(delta.entity).unwrap();
        let _host =  &_mut;
        delta.getters().text(&_host).into_value().get()
    };
    let _v_e_delta = {
        let _host = e;
        e.getters().delta(&_host).into_value().get()
    };
    let _v_elapsed_text = {
        let _inset = _params.p0();
        let _mut = _inset.get(elapsed.entity).unwrap();
        let _host =  &_mut;
        elapsed.getters().text(&_host).into_value().get()
    };
    let _v_elapsed_bg_g = {
        let _inset = _params.p2();
        let _mut = _inset.get(elapsed.entity).unwrap();
        let _host =  &_mut;
        elapsed.getters().bg(&_host).g().into_value().get()
    };
    
    // apply changes
    
    {
        let _val = ({
            let res = format!("Frame time: {:0.4}",_v_e_delta);
            res
        }).into();
        if _v_delta_text!=_val {
            delta.setters().set_text(_params.p0().get_mut(delta.entity).unwrap().as_mut(),_val);
            delta.descriptor().text().notify_changed(_commands, delta.entity);
        }
    };
    {
        let _val = ({
            let res = format!("Elapsed time: {:0.2}",_v_time_elapsed);
            res
        }).into();
        if _v_elapsed_text != _val {
            elapsed.setters().set_text(_params.p0().get_mut(elapsed.entity).unwrap().as_mut(),_val);
            elapsed.descriptor().text().notify_changed(_commands, elapsed.entity);
        }
    };
    {
        let _val = ((_v_time_elapsed-2.)*0.5).into();
        if _v_elapsed_bg_g != _val {
            elapsed.setters().bg(_params.p2().get_mut(elapsed.entity).unwrap().as_mut()).set_g(_val);
            elapsed.descriptor().bg().notify_changed(_commands, elapsed.entity);
        }
    };
});
```

While this System is suboptimal, there is a lot of space for optimisations.

### On-demand Signals

There are two on-demand signals right now: `EnterSignal` & `UpdateSignal`. Emitting this signal on every entity is ineffective and useless. So I want to emit this signals only on entities with handles. So when I connect to `.on.enter` or `.on.update` - the signals start to emit on the connected entities.

### Hand syntax. 

Hands are supposed to be very simple blocks of code. So the syntax right now is very limited.

Statements (`STMT`):
- assign: `mark.prop = EXPR;`
- emit signal: `mark.signal.emit(ARGS);`
- send event: `MyEvent::send(ARGS);`|`send(MyEvent[, ARGS]);`
- if: `if EXPR { STMT+ } [ elif EXPR { STMT+ } ]* [ else { STMT+  } ]`

Expressions (`EXPR`):
- const: `LITERAL`
- read: `mark.prop`
- format: `EXPR.fmt(STR)`
- group: `(EXPR)`
- add: `EXPR + EXPR`
- sub: `EXPR - EXPR`
- mul: `EXPR * EXPR`
- div: `EXPR / EXPR`

Arguments (`ARGS`):
- empty: ` `
- single: `.name: EXPR`
- multi: `.name: EXPR [, .name: EXPR]*`

### Status
- [x] Derive signal
- [x] Assign signal to Element/Behavior
- [x] On-demand signals
- [x] `.on.signal:` param extension
- [ ] statements
  - [x] assign: `mark.prop = EXPR`
  - [ ] emit signal
  - [ ] send event
  - [x] if
- [x] expressions:
  - [x] const
  - [x] read
  - [ ] enum
  - [ ] construct
  - [x] format
  - [x] group
  - [x] add/sub/mul/div
  - [x] gt/gte/lt/lte
  - [x] and/or
  - [x] eq/ne
  - [x] neg/not
